### PR TITLE
feat(domain): add Author entity with N:M relationship support

### DIFF
--- a/apps/api-cli/src/domain/entities/Author.ts
+++ b/apps/api-cli/src/domain/entities/Author.ts
@@ -1,0 +1,153 @@
+/**
+ * Author Entity
+ *
+ * Represents an author that can be associated with books.
+ * Authors are reusable and managed independently with N:M relationship to Books.
+ *
+ * Entities are:
+ * - Identified by a unique ID (not by their attributes)
+ * - Mutable through controlled methods
+ * - Responsible for maintaining their own invariants
+ *
+ * This entity follows an immutable pattern - all "mutations" return new instances.
+ */
+
+import {
+  RequiredFieldError,
+  FieldTooLongError,
+  InvalidUUIDError,
+} from '../errors/DomainErrors.js';
+
+/**
+ * Field length constraints
+ */
+const FIELD_CONSTRAINTS = {
+  NAME_MAX_LENGTH: 300,
+} as const;
+
+/**
+ * UUID v4 regex pattern
+ */
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Props required to create a new Author
+ */
+export interface CreateAuthorProps {
+  id: string;
+  name: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+/**
+ * Props for reconstructing an Author from persistence
+ */
+export interface AuthorPersistenceProps {
+  id: string;
+  name: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Props that can be updated on an Author
+ */
+export interface UpdateAuthorProps {
+  name?: string;
+}
+
+/**
+ * Author Entity
+ */
+export class Author {
+  private constructor(
+    public readonly id: string,
+    public readonly name: string,
+    public readonly createdAt: Date,
+    public readonly updatedAt: Date
+  ) {
+    Object.freeze(this);
+  }
+
+  /**
+   * Creates a new Author instance with full validation
+   * Use this when creating an author from user input
+   */
+  static create(props: CreateAuthorProps): Author {
+    const id = Author.validateId(props.id);
+    const name = Author.validateName(props.name);
+
+    const now = new Date();
+    const createdAt = props.createdAt ?? now;
+    const updatedAt = props.updatedAt ?? now;
+
+    return new Author(id, name, createdAt, updatedAt);
+  }
+
+  /**
+   * Reconstructs an Author from persistence without validation
+   * Use this when loading an author from the database
+   */
+  static fromPersistence(props: AuthorPersistenceProps): Author {
+    return new Author(
+      props.id,
+      props.name,
+      props.createdAt,
+      props.updatedAt
+    );
+  }
+
+  /**
+   * Updates the author with new values, returning a new instance
+   */
+  update(props: UpdateAuthorProps): Author {
+    const name = props.name !== undefined
+      ? Author.validateName(props.name)
+      : this.name;
+
+    return new Author(
+      this.id,
+      name,
+      this.createdAt,
+      new Date() // Update timestamp
+    );
+  }
+
+  /**
+   * Compares two Author instances by ID
+   */
+  equals(other: Author): boolean {
+    return this.id === other.id;
+  }
+
+  // ==================== Private Validators ====================
+
+  private static validateId(id: string): string {
+    if (!id || id.trim().length === 0) {
+      throw new RequiredFieldError('id');
+    }
+
+    const trimmedId = id.trim();
+
+    if (!UUID_REGEX.test(trimmedId)) {
+      throw new InvalidUUIDError(id);
+    }
+
+    return trimmedId;
+  }
+
+  private static validateName(name: string): string {
+    if (!name || name.trim().length === 0) {
+      throw new RequiredFieldError('name');
+    }
+
+    const trimmedName = name.trim();
+
+    if (trimmedName.length > FIELD_CONSTRAINTS.NAME_MAX_LENGTH) {
+      throw new FieldTooLongError('name', FIELD_CONSTRAINTS.NAME_MAX_LENGTH);
+    }
+
+    return trimmedName;
+  }
+}

--- a/apps/api-cli/src/domain/entities/index.ts
+++ b/apps/api-cli/src/domain/entities/index.ts
@@ -3,6 +3,13 @@
  */
 
 export {
+  Author,
+  type CreateAuthorProps,
+  type AuthorPersistenceProps,
+  type UpdateAuthorProps,
+} from './Author.js';
+
+export {
   Book,
   type CreateBookProps,
   type BookPersistenceProps,

--- a/apps/api-cli/tests/unit/domain/entities/Author.test.ts
+++ b/apps/api-cli/tests/unit/domain/entities/Author.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  Author,
+  type CreateAuthorProps,
+  type AuthorPersistenceProps,
+} from '../../../../src/domain/entities/Author.js';
+import {
+  RequiredFieldError,
+  FieldTooLongError,
+  InvalidUUIDError,
+} from '../../../../src/domain/errors/DomainErrors.js';
+
+describe('Author', () => {
+  const validUUID = '550e8400-e29b-41d4-a716-446655440000';
+
+  const createValidAuthorProps = (
+    overrides?: Partial<CreateAuthorProps>
+  ): CreateAuthorProps => ({
+    id: validUUID,
+    name: 'Robert C. Martin',
+    ...overrides,
+  });
+
+  const createValidPersistenceProps = (
+    overrides?: Partial<AuthorPersistenceProps>
+  ): AuthorPersistenceProps => ({
+    id: validUUID,
+    name: 'Robert C. Martin',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    ...overrides,
+  });
+
+  describe('create', () => {
+    it('should create a valid Author with required fields', () => {
+      const props = createValidAuthorProps();
+      const author = Author.create(props);
+
+      expect(author.id).toBe(validUUID);
+      expect(author.name).toBe('Robert C. Martin');
+    });
+
+    it('should trim whitespace from name', () => {
+      const props = createValidAuthorProps({
+        name: '  Robert C. Martin  ',
+      });
+
+      const author = Author.create(props);
+
+      expect(author.name).toBe('Robert C. Martin');
+    });
+
+    it('should preserve original case of name', () => {
+      const props = createValidAuthorProps({
+        name: 'Martin FOWLER',
+      });
+
+      const author = Author.create(props);
+      expect(author.name).toBe('Martin FOWLER');
+    });
+
+    it('should set createdAt and updatedAt to now if not provided', () => {
+      const before = new Date();
+      const author = Author.create(createValidAuthorProps());
+      const after = new Date();
+
+      expect(author.createdAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(author.createdAt.getTime()).toBeLessThanOrEqual(after.getTime());
+      expect(author.updatedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(author.updatedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+
+    it('should use provided createdAt and updatedAt', () => {
+      const createdAt = new Date('2024-01-01');
+      const updatedAt = new Date('2024-06-15');
+
+      const author = Author.create(createValidAuthorProps({ createdAt, updatedAt }));
+
+      expect(author.createdAt).toEqual(createdAt);
+      expect(author.updatedAt).toEqual(updatedAt);
+    });
+
+    describe('validation errors', () => {
+      describe('id', () => {
+        it('should throw RequiredFieldError for empty id', () => {
+          expect(() => Author.create(createValidAuthorProps({ id: '' }))).toThrow(
+            RequiredFieldError
+          );
+        });
+
+        it('should throw RequiredFieldError for whitespace-only id', () => {
+          expect(() => Author.create(createValidAuthorProps({ id: '   ' }))).toThrow(
+            RequiredFieldError
+          );
+        });
+
+        it('should throw InvalidUUIDError for invalid UUID format', () => {
+          expect(() =>
+            Author.create(createValidAuthorProps({ id: 'not-a-uuid' }))
+          ).toThrow(InvalidUUIDError);
+        });
+
+        it('should throw InvalidUUIDError for UUID v1 (not v4)', () => {
+          expect(() =>
+            Author.create(
+              createValidAuthorProps({ id: '550e8400-e29b-11d4-a716-446655440000' })
+            )
+          ).toThrow(InvalidUUIDError);
+        });
+      });
+
+      describe('name', () => {
+        it('should throw RequiredFieldError for empty name', () => {
+          expect(() => Author.create(createValidAuthorProps({ name: '' }))).toThrow(
+            RequiredFieldError
+          );
+        });
+
+        it('should throw RequiredFieldError for whitespace-only name', () => {
+          expect(() =>
+            Author.create(createValidAuthorProps({ name: '   ' }))
+          ).toThrow(RequiredFieldError);
+        });
+
+        it('should throw FieldTooLongError for name exceeding 300 chars', () => {
+          const longName = 'A'.repeat(301);
+          expect(() =>
+            Author.create(createValidAuthorProps({ name: longName }))
+          ).toThrow(FieldTooLongError);
+        });
+
+        it('should accept name with exactly 300 chars', () => {
+          const maxName = 'A'.repeat(300);
+          const author = Author.create(createValidAuthorProps({ name: maxName }));
+          expect(author.name).toBe(maxName);
+        });
+      });
+    });
+  });
+
+  describe('fromPersistence', () => {
+    it('should reconstruct an Author without validation', () => {
+      const props = createValidPersistenceProps();
+      const author = Author.fromPersistence(props);
+
+      expect(author.id).toBe(validUUID);
+      expect(author.name).toBe('Robert C. Martin');
+    });
+
+    it('should reconstruct an Author with all fields', () => {
+      const createdAt = new Date('2024-01-01');
+      const updatedAt = new Date('2024-06-15');
+      const props = createValidPersistenceProps({
+        createdAt,
+        updatedAt,
+      });
+
+      const author = Author.fromPersistence(props);
+
+      expect(author.createdAt).toEqual(createdAt);
+      expect(author.updatedAt).toEqual(updatedAt);
+    });
+
+    it('should not validate when reconstructing from persistence', () => {
+      // This should not throw even with "invalid" data
+      // because persistence data is trusted
+      const props = createValidPersistenceProps({
+        name: '', // Empty name would fail validation in create()
+      });
+
+      // fromPersistence trusts the data
+      const author = Author.fromPersistence(props);
+      expect(author.name).toBe('');
+    });
+  });
+
+  describe('update', () => {
+    let author: Author;
+
+    beforeEach(() => {
+      author = Author.create(createValidAuthorProps());
+    });
+
+    it('should return a new Author instance', () => {
+      const updated = author.update({ name: 'New Name' });
+      expect(updated).not.toBe(author);
+    });
+
+    it('should update name', () => {
+      const updated = author.update({ name: 'Martin Fowler' });
+      expect(updated.name).toBe('Martin Fowler');
+      expect(author.name).toBe('Robert C. Martin'); // Original unchanged
+    });
+
+    it('should trim whitespace from updated name', () => {
+      const updated = author.update({ name: '  Martin Fowler  ' });
+      expect(updated.name).toBe('Martin Fowler');
+    });
+
+    it('should preserve id and createdAt', () => {
+      const updated = author.update({ name: 'New Name' });
+
+      expect(updated.id).toBe(author.id);
+      expect(updated.createdAt).toEqual(author.createdAt);
+    });
+
+    it('should update updatedAt timestamp', () => {
+      const before = new Date();
+      const updated = author.update({ name: 'New Name' });
+      const after = new Date();
+
+      expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(updated.updatedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+
+    it('should validate updated fields', () => {
+      expect(() => author.update({ name: '' })).toThrow(RequiredFieldError);
+    });
+
+    it('should throw FieldTooLongError for name exceeding 300 chars', () => {
+      const longName = 'A'.repeat(301);
+      expect(() => author.update({ name: longName })).toThrow(FieldTooLongError);
+    });
+  });
+
+  describe('equals', () => {
+    it('should return true for Authors with same id', () => {
+      const author1 = Author.create(createValidAuthorProps());
+      const author2 = Author.create(createValidAuthorProps({ name: 'Different Name' }));
+
+      expect(author1.equals(author2)).toBe(true);
+    });
+
+    it('should return false for Authors with different ids', () => {
+      const author1 = Author.create(createValidAuthorProps());
+      const author2 = Author.create(
+        createValidAuthorProps({ id: '660e8400-e29b-41d4-a716-446655440000' })
+      );
+
+      expect(author1.equals(author2)).toBe(false);
+    });
+  });
+
+  describe('immutability', () => {
+    it('should be frozen', () => {
+      const author = Author.create(createValidAuthorProps());
+      expect(Object.isFrozen(author)).toBe(true);
+    });
+
+    it('should not allow property modification', () => {
+      const author = Author.create(createValidAuthorProps());
+      expect(() => {
+        // @ts-expect-error - Testing runtime immutability
+        author.name = 'New Name';
+      }).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add new `Author` entity to support N:M relationship with books
- Follow DDD patterns consistent with existing `Category` entity
- Enable multiple authors per book as required by HU-002

## Author Entity

| Field | Type | Description |
|-------|------|-------------|
| `id` | UUID | Unique identifier |
| `name` | string | Author name (max 300 chars, unique) |
| `createdAt` | Date | Creation timestamp |
| `updatedAt` | Date | Last update timestamp |

## Implementation

- **`create()`**: Factory method with full validation for user input
- **`fromPersistence()`**: Reconstruction from database (trusts data)
- **`update()`**: Returns new immutable instance with updated fields
- **`equals()`**: ID-based entity comparison
- **Immutability**: All instances are frozen with `Object.freeze()`

## Tests

Added 27 unit tests covering:
- Valid creation scenarios
- All validation errors (RequiredFieldError, FieldTooLongError, InvalidUUIDError)
- Persistence reconstruction
- Update operations
- Entity equality
- Immutability guarantees

## Related

Closes #69
Part of #66