### PR TITLE
feat(domain): add BookType entity (TASK-004)

### DIFF
--- a/apps/api-cli/src/domain/entities/BookType.ts
+++ b/apps/api-cli/src/domain/entities/BookType.ts
@@ -1,0 +1,179 @@
+/**
+ * BookType Entity
+ *
+ * Represents the type/genre classification of a book.
+ * This is a high-level categorization (technical, novel, biography, etc.)
+ *
+ * BookType was converted from a Value Object to an Entity to support:
+ * - Persistence in database with unique ID
+ * - N:1 relationship with Books
+ * - Future extensibility (adding new types without code changes)
+ *
+ * Entities are:
+ * - Identified by a unique ID (not by their attributes)
+ * - Mutable through controlled methods
+ * - Responsible for maintaining their own invariants
+ *
+ * This entity follows an immutable pattern - all "mutations" return new instances.
+ */
+
+import {
+  RequiredFieldError,
+  FieldTooLongError,
+  InvalidUUIDError,
+} from '../errors/DomainErrors.js';
+
+/**
+ * Field length constraints
+ */
+const FIELD_CONSTRAINTS = {
+  NAME_MAX_LENGTH: 50,
+} as const;
+
+/**
+ * UUID v4 regex pattern
+ */
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Default book types that should be seeded in the database
+ */
+export const DEFAULT_BOOK_TYPES = ['technical', 'novel', 'biography'] as const;
+
+export type DefaultBookTypeName = (typeof DEFAULT_BOOK_TYPES)[number];
+
+/**
+ * Props required to create a new BookType
+ */
+export interface CreateBookTypeProps {
+  id: string;
+  name: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+/**
+ * Props for reconstructing a BookType from persistence
+ */
+export interface BookTypePersistenceProps {
+  id: string;
+  name: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Props that can be updated on a BookType
+ */
+export interface UpdateBookTypeProps {
+  name?: string;
+}
+
+/**
+ * BookType Entity
+ */
+export class BookType {
+  private constructor(
+    public readonly id: string,
+    public readonly name: string,
+    public readonly createdAt: Date,
+    public readonly updatedAt: Date
+  ) {
+    Object.freeze(this);
+  }
+
+  /**
+   * Creates a new BookType instance with full validation
+   * Use this when creating a book type from user input
+   */
+  static create(props: CreateBookTypeProps): BookType {
+    const id = BookType.validateId(props.id);
+    const name = BookType.validateName(props.name);
+
+    const now = new Date();
+    const createdAt = props.createdAt ?? now;
+    const updatedAt = props.updatedAt ?? now;
+
+    return new BookType(id, name, createdAt, updatedAt);
+  }
+
+  /**
+   * Reconstructs a BookType from persistence without validation
+   * Use this when loading a book type from the database
+   */
+  static fromPersistence(props: BookTypePersistenceProps): BookType {
+    return new BookType(
+      props.id,
+      props.name,
+      props.createdAt,
+      props.updatedAt
+    );
+  }
+
+  /**
+   * Updates the book type with new values, returning a new instance
+   */
+  update(props: UpdateBookTypeProps): BookType {
+    const name = props.name !== undefined
+      ? BookType.validateName(props.name)
+      : this.name;
+
+    return new BookType(
+      this.id,
+      name,
+      this.createdAt,
+      new Date() // Update timestamp
+    );
+  }
+
+  /**
+   * Compares two BookType instances by ID (Entity comparison)
+   */
+  equals(other: BookType): boolean {
+    return this.id === other.id;
+  }
+
+  /**
+   * Checks if the book type has the given name
+   */
+  hasName(name: string): boolean {
+    return this.name.toLowerCase() === name.toLowerCase();
+  }
+
+  /**
+   * Returns string representation
+   */
+  toString(): string {
+    return this.name;
+  }
+
+  // ==================== Private Validators ====================
+
+  private static validateId(id: string): string {
+    if (!id || id.trim().length === 0) {
+      throw new RequiredFieldError('id');
+    }
+
+    const trimmedId = id.trim();
+
+    if (!UUID_REGEX.test(trimmedId)) {
+      throw new InvalidUUIDError(id);
+    }
+
+    return trimmedId;
+  }
+
+  private static validateName(name: string): string {
+    if (!name || name.trim().length === 0) {
+      throw new RequiredFieldError('name');
+    }
+
+    const trimmedName = name.trim().toLowerCase();
+
+    if (trimmedName.length > FIELD_CONSTRAINTS.NAME_MAX_LENGTH) {
+      throw new FieldTooLongError('name', FIELD_CONSTRAINTS.NAME_MAX_LENGTH);
+    }
+
+    return trimmedName;
+  }
+}

--- a/apps/api-cli/src/domain/entities/index.ts
+++ b/apps/api-cli/src/domain/entities/index.ts
@@ -17,6 +17,15 @@ export {
 } from './Book.js';
 
 export {
+  BookType,
+  DEFAULT_BOOK_TYPES,
+  type DefaultBookTypeName,
+  type CreateBookTypeProps,
+  type BookTypePersistenceProps,
+  type UpdateBookTypeProps,
+} from './BookType.js';
+
+export {
   Category,
   type CreateCategoryProps,
   type CategoryPersistenceProps,

--- a/apps/api-cli/src/domain/errors/DomainErrors.ts
+++ b/apps/api-cli/src/domain/errors/DomainErrors.ts
@@ -122,6 +122,18 @@ export class DuplicateItemError extends DomainError {
   }
 }
 
+/**
+ * Thrown when an invalid book type is provided
+ */
+export class InvalidBookTypeError extends DomainError {
+  constructor(value: string, validTypes?: readonly string[]) {
+    const validTypesMessage = validTypes
+      ? `. Valid types are: ${validTypes.join(', ')}`
+      : '';
+    super(`Invalid book type: "${value}"${validTypesMessage}`);
+  }
+}
+
 // ==================== Application/Infrastructure Errors ====================
 
 /**

--- a/apps/api-cli/src/domain/errors/index.ts
+++ b/apps/api-cli/src/domain/errors/index.ts
@@ -15,9 +15,9 @@ export {
   InvalidUUIDError,
   TooManyItemsError,
   DuplicateItemError,
+  InvalidBookTypeError,
 } from './DomainErrors.js';
 
 // Re-export Value Object errors for convenience
-export { InvalidBookTypeError } from '../value-objects/BookType.js';
 export { InvalidBookFormatError } from '../value-objects/BookFormat.js';
 export { InvalidISBNError } from '../value-objects/ISBN.js';

--- a/apps/api-cli/src/domain/index.ts
+++ b/apps/api-cli/src/domain/index.ts
@@ -13,7 +13,34 @@ export {
   type UpdateBookProps,
 } from './entities/index.js';
 
+export {
+  Author,
+  type CreateAuthorProps,
+  type AuthorPersistenceProps,
+  type UpdateAuthorProps,
+} from './entities/index.js';
+
+export {
+  BookType as BookTypeEntity,
+  DEFAULT_BOOK_TYPES,
+  type DefaultBookTypeName,
+  type CreateBookTypeProps,
+  type BookTypePersistenceProps,
+  type UpdateBookTypeProps,
+} from './entities/index.js';
+
+export {
+  Category,
+  type CreateCategoryProps,
+  type CategoryPersistenceProps,
+  type UpdateCategoryProps,
+} from './entities/index.js';
+
 // Value Objects
+/**
+ * @deprecated BookType VO is being replaced by BookTypeEntity.
+ * Use BookTypeEntity from entities for new code.
+ */
 export {
   BookType,
   BOOK_TYPES,

--- a/apps/api-cli/src/domain/value-objects/BookType.ts
+++ b/apps/api-cli/src/domain/value-objects/BookType.ts
@@ -8,7 +8,13 @@
  * - Immutable
  * - Compared by value, not identity
  * - Self-validating
+ *
+ * @deprecated This Value Object is being replaced by the BookType Entity.
+ * Use src/domain/entities/BookType.ts for new code.
+ * This file will be removed in TASK-005 when Book entity is updated.
  */
+
+import { InvalidBookTypeError } from '../errors/DomainErrors.js';
 
 export const BOOK_TYPES = [
   'technical',
@@ -36,7 +42,7 @@ export class BookType {
     const normalizedValue = value.toLowerCase().trim();
 
     if (!BookType.isValid(normalizedValue)) {
-      throw new InvalidBookTypeError(value);
+      throw new InvalidBookTypeError(value, BOOK_TYPES);
     }
 
     return new BookType(normalizedValue as BookTypeValue);
@@ -76,14 +82,5 @@ export class BookType {
   }
 }
 
-/**
- * Error thrown when an invalid book type is provided
- */
-export class InvalidBookTypeError extends Error {
-  constructor(value: string) {
-    super(
-      `Invalid book type: "${value}". Valid types are: ${BOOK_TYPES.join(', ')}`
-    );
-    this.name = 'InvalidBookTypeError';
-  }
-}
+// Re-export error for backward compatibility
+export { InvalidBookTypeError } from '../errors/DomainErrors.js';

--- a/apps/api-cli/src/domain/value-objects/index.ts
+++ b/apps/api-cli/src/domain/value-objects/index.ts
@@ -2,6 +2,14 @@
  * Value Objects barrel export
  */
 
-export { BookType, BOOK_TYPES, type BookTypeValue, InvalidBookTypeError } from './BookType.js';
+/**
+ * @deprecated BookType Value Object is being replaced by BookType Entity.
+ * Import from 'domain/entities' for new code.
+ */
+export { BookType, BOOK_TYPES, type BookTypeValue } from './BookType.js';
+
 export { BookFormat, BOOK_FORMATS, type BookFormatValue, InvalidBookFormatError } from './BookFormat.js';
 export { ISBN, InvalidISBNError } from './ISBN.js';
+
+// Re-export InvalidBookTypeError from errors for backward compatibility
+export { InvalidBookTypeError } from '../errors/DomainErrors.js';

--- a/apps/api-cli/tests/unit/domain/entities/BookType.test.ts
+++ b/apps/api-cli/tests/unit/domain/entities/BookType.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  BookType,
+  type CreateBookTypeProps,
+  type BookTypePersistenceProps,
+  DEFAULT_BOOK_TYPES,
+} from '../../../../src/domain/entities/BookType.js';
+import {
+  RequiredFieldError,
+  FieldTooLongError,
+  InvalidUUIDError,
+} from '../../../../src/domain/errors/DomainErrors.js';
+
+describe('BookType', () => {
+  const validUUID = '550e8400-e29b-41d4-a716-446655440000';
+
+  const createValidBookTypeProps = (
+    overrides?: Partial<CreateBookTypeProps>
+  ): CreateBookTypeProps => ({
+    id: validUUID,
+    name: 'technical',
+    ...overrides,
+  });
+
+  const createValidPersistenceProps = (
+    overrides?: Partial<BookTypePersistenceProps>
+  ): BookTypePersistenceProps => ({
+    id: validUUID,
+    name: 'technical',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    ...overrides,
+  });
+
+  describe('DEFAULT_BOOK_TYPES', () => {
+    it('should include technical, novel, and biography', () => {
+      expect(DEFAULT_BOOK_TYPES).toContain('technical');
+      expect(DEFAULT_BOOK_TYPES).toContain('novel');
+      expect(DEFAULT_BOOK_TYPES).toContain('biography');
+    });
+
+    it('should have exactly 3 default types', () => {
+      expect(DEFAULT_BOOK_TYPES).toHaveLength(3);
+    });
+  });
+
+  describe('create', () => {
+    it('should create a valid BookType with required fields', () => {
+      const props = createValidBookTypeProps();
+      const bookType = BookType.create(props);
+
+      expect(bookType.id).toBe(validUUID);
+      expect(bookType.name).toBe('technical');
+    });
+
+    it('should trim whitespace from name', () => {
+      const props = createValidBookTypeProps({
+        name: '  technical  ',
+      });
+
+      const bookType = BookType.create(props);
+
+      expect(bookType.name).toBe('technical');
+    });
+
+    it('should normalize name to lowercase', () => {
+      const props = createValidBookTypeProps({
+        name: 'TECHNICAL',
+      });
+
+      const bookType = BookType.create(props);
+      expect(bookType.name).toBe('technical');
+    });
+
+    it('should set createdAt and updatedAt to now if not provided', () => {
+      const before = new Date();
+      const bookType = BookType.create(createValidBookTypeProps());
+      const after = new Date();
+
+      expect(bookType.createdAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(bookType.createdAt.getTime()).toBeLessThanOrEqual(after.getTime());
+      expect(bookType.updatedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(bookType.updatedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+
+    it('should use provided createdAt and updatedAt', () => {
+      const createdAt = new Date('2024-01-01');
+      const updatedAt = new Date('2024-06-15');
+
+      const bookType = BookType.create(createValidBookTypeProps({ createdAt, updatedAt }));
+
+      expect(bookType.createdAt).toEqual(createdAt);
+      expect(bookType.updatedAt).toEqual(updatedAt);
+    });
+
+    describe('validation errors', () => {
+      describe('id', () => {
+        it('should throw RequiredFieldError for empty id', () => {
+          expect(() => BookType.create(createValidBookTypeProps({ id: '' }))).toThrow(
+            RequiredFieldError
+          );
+        });
+
+        it('should throw RequiredFieldError for whitespace-only id', () => {
+          expect(() => BookType.create(createValidBookTypeProps({ id: '   ' }))).toThrow(
+            RequiredFieldError
+          );
+        });
+
+        it('should throw InvalidUUIDError for invalid UUID format', () => {
+          expect(() =>
+            BookType.create(createValidBookTypeProps({ id: 'not-a-uuid' }))
+          ).toThrow(InvalidUUIDError);
+        });
+
+        it('should throw InvalidUUIDError for UUID v1 (not v4)', () => {
+          expect(() =>
+            BookType.create(
+              createValidBookTypeProps({ id: '550e8400-e29b-11d4-a716-446655440000' })
+            )
+          ).toThrow(InvalidUUIDError);
+        });
+      });
+
+      describe('name', () => {
+        it('should throw RequiredFieldError for empty name', () => {
+          expect(() => BookType.create(createValidBookTypeProps({ name: '' }))).toThrow(
+            RequiredFieldError
+          );
+        });
+
+        it('should throw RequiredFieldError for whitespace-only name', () => {
+          expect(() =>
+            BookType.create(createValidBookTypeProps({ name: '   ' }))
+          ).toThrow(RequiredFieldError);
+        });
+
+        it('should throw FieldTooLongError for name exceeding 50 chars', () => {
+          const longName = 'A'.repeat(51);
+          expect(() =>
+            BookType.create(createValidBookTypeProps({ name: longName }))
+          ).toThrow(FieldTooLongError);
+        });
+
+        it('should accept name with exactly 50 chars', () => {
+          const maxName = 'a'.repeat(50);
+          const bookType = BookType.create(createValidBookTypeProps({ name: maxName }));
+          expect(bookType.name).toBe(maxName);
+        });
+      });
+    });
+  });
+
+  describe('fromPersistence', () => {
+    it('should reconstruct a BookType without validation', () => {
+      const props = createValidPersistenceProps();
+      const bookType = BookType.fromPersistence(props);
+
+      expect(bookType.id).toBe(validUUID);
+      expect(bookType.name).toBe('technical');
+    });
+
+    it('should reconstruct a BookType with all fields', () => {
+      const createdAt = new Date('2024-01-01');
+      const updatedAt = new Date('2024-06-15');
+      const props = createValidPersistenceProps({
+        createdAt,
+        updatedAt,
+      });
+
+      const bookType = BookType.fromPersistence(props);
+
+      expect(bookType.createdAt).toEqual(createdAt);
+      expect(bookType.updatedAt).toEqual(updatedAt);
+    });
+
+    it('should not validate when reconstructing from persistence', () => {
+      // This should not throw even with "invalid" data
+      // because persistence data is trusted
+      const props = createValidPersistenceProps({
+        name: '', // Empty name would fail validation in create()
+      });
+
+      // fromPersistence trusts the data
+      const bookType = BookType.fromPersistence(props);
+      expect(bookType.name).toBe('');
+    });
+  });
+
+  describe('update', () => {
+    let bookType: BookType;
+
+    beforeEach(() => {
+      bookType = BookType.create(createValidBookTypeProps());
+    });
+
+    it('should return a new BookType instance', () => {
+      const updated = bookType.update({ name: 'novel' });
+      expect(updated).not.toBe(bookType);
+    });
+
+    it('should update name', () => {
+      const updated = bookType.update({ name: 'novel' });
+      expect(updated.name).toBe('novel');
+      expect(bookType.name).toBe('technical'); // Original unchanged
+    });
+
+    it('should trim whitespace from updated name', () => {
+      const updated = bookType.update({ name: '  novel  ' });
+      expect(updated.name).toBe('novel');
+    });
+
+    it('should normalize updated name to lowercase', () => {
+      const updated = bookType.update({ name: 'NOVEL' });
+      expect(updated.name).toBe('novel');
+    });
+
+    it('should preserve id and createdAt', () => {
+      const updated = bookType.update({ name: 'novel' });
+
+      expect(updated.id).toBe(bookType.id);
+      expect(updated.createdAt).toEqual(bookType.createdAt);
+    });
+
+    it('should update updatedAt timestamp', () => {
+      const before = new Date();
+      const updated = bookType.update({ name: 'novel' });
+      const after = new Date();
+
+      expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(updated.updatedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+
+    it('should validate updated fields', () => {
+      expect(() => bookType.update({ name: '' })).toThrow(RequiredFieldError);
+    });
+
+    it('should throw FieldTooLongError for name exceeding 50 chars', () => {
+      const longName = 'A'.repeat(51);
+      expect(() => bookType.update({ name: longName })).toThrow(FieldTooLongError);
+    });
+  });
+
+  describe('equals', () => {
+    it('should return true for BookTypes with same id', () => {
+      const bookType1 = BookType.create(createValidBookTypeProps());
+      const bookType2 = BookType.create(createValidBookTypeProps({ name: 'novel' }));
+
+      expect(bookType1.equals(bookType2)).toBe(true);
+    });
+
+    it('should return false for BookTypes with different ids', () => {
+      const bookType1 = BookType.create(createValidBookTypeProps());
+      const bookType2 = BookType.create(
+        createValidBookTypeProps({ id: '660e8400-e29b-41d4-a716-446655440000' })
+      );
+
+      expect(bookType1.equals(bookType2)).toBe(false);
+    });
+  });
+
+  describe('hasName', () => {
+    it('should return true for exact match', () => {
+      const bookType = BookType.create(createValidBookTypeProps({ name: 'technical' }));
+      expect(bookType.hasName('technical')).toBe(true);
+    });
+
+    it('should return true for case-insensitive match', () => {
+      const bookType = BookType.create(createValidBookTypeProps({ name: 'technical' }));
+      expect(bookType.hasName('TECHNICAL')).toBe(true);
+      expect(bookType.hasName('Technical')).toBe(true);
+    });
+
+    it('should return false for non-matching name', () => {
+      const bookType = BookType.create(createValidBookTypeProps({ name: 'technical' }));
+      expect(bookType.hasName('novel')).toBe(false);
+    });
+  });
+
+  describe('toString', () => {
+    it('should return the name', () => {
+      const bookType = BookType.create(createValidBookTypeProps({ name: 'technical' }));
+      expect(bookType.toString()).toBe('technical');
+    });
+  });
+
+  describe('immutability', () => {
+    it('should be frozen', () => {
+      const bookType = BookType.create(createValidBookTypeProps());
+      expect(Object.isFrozen(bookType)).toBe(true);
+    });
+
+    it('should not allow property modification', () => {
+      const bookType = BookType.create(createValidBookTypeProps());
+      expect(() => {
+        // @ts-expect-error - Testing runtime immutability
+        bookType.name = 'novel';
+      }).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add new `BookType` entity to replace the existing Value Object, supporting persistence with UUID, name, and timestamps
- Move `InvalidBookTypeError` to `DomainErrors.ts` for better organization
- Mark Value Object as deprecated (to be fully removed in TASK-005 when Book entity is updated)

## Changes

### New Files
- `src/domain/entities/BookType.ts` - Entity with `id`, `name`, `createdAt`, `updatedAt`
- `tests/unit/domain/entities/BookType.test.ts` - 34 comprehensive unit tests

### Modified Files
- `src/domain/entities/index.ts` - Export new entity
- `src/domain/errors/DomainErrors.ts` - Added `InvalidBookTypeError`
- `src/domain/errors/index.ts` - Updated exports
- `src/domain/index.ts` - Export `BookTypeEntity` for new code
- `src/domain/value-objects/BookType.ts` - Marked as `@deprecated`
- `src/domain/value-objects/index.ts` - Updated with deprecation notice

## Testing

- ✅ 406 unit tests passing
- ✅ 63 integration tests passing
- ✅ 30 e2e tests passing (+ 2 skipped as expected)

## Notes

The Value Object is kept temporarily for backward compatibility. Full removal will occur in TASK-005 when the `Book` entity is updated to use `BookType` entity and `Author[]`."