### PR TITLE
feat(persistence): implement AuthorRepository port and adapter

### DIFF
--- a/apps/api-cli/src/application/ports/AuthorRepository.ts
+++ b/apps/api-cli/src/application/ports/AuthorRepository.ts
@@ -1,0 +1,91 @@
+/**
+ * AuthorRepository Port (Driven/Output Port)
+ *
+ * Defines the contract for author persistence operations.
+ * This is a port in the hexagonal architecture - the actual implementation
+ * (e.g., PostgresAuthorRepository) will be an adapter in the infrastructure layer.
+ *
+ * Authors have a N:M relationship with Books via the book_authors junction table.
+ */
+
+import type { Author } from '../../domain/entities/Author.js';
+
+/**
+ * AuthorRepository Port Interface
+ *
+ * Provides operations for managing authors in the persistence layer.
+ * Used by the CreateBook use case to handle author auto-creation.
+ */
+export interface AuthorRepository {
+  /**
+   * Finds an author by its unique identifier
+   *
+   * @param id - The author UUID
+   * @returns Promise resolving to the Author if found, null otherwise
+   */
+  findById(id: string): Promise<Author | null>;
+
+  /**
+   * Finds an author by its name (case-sensitive exact match)
+   *
+   * Note: Author names are stored as-is (not normalized) for display purposes,
+   * but deduplication should consider case-insensitive matching in findOrCreate.
+   *
+   * @param name - The author name to search for
+   * @returns Promise resolving to the Author if found, null otherwise
+   */
+  findByName(name: string): Promise<Author | null>;
+
+  /**
+   * Finds multiple authors by their names
+   *
+   * @param names - Array of author names to search for
+   * @returns Promise resolving to an array of found Authors (may be fewer than input)
+   */
+  findByNames(names: string[]): Promise<Author[]>;
+
+  /**
+   * Finds an author by name or creates it if it doesn't exist
+   *
+   * This is an atomic operation - if the author doesn't exist,
+   * it will be created with a new UUID.
+   *
+   * @param name - The author name
+   * @returns Promise resolving to the existing or newly created Author
+   */
+  findOrCreate(name: string): Promise<Author>;
+
+  /**
+   * Finds or creates multiple authors by their names
+   *
+   * This is an atomic operation for batch processing.
+   * Authors that don't exist will be created.
+   *
+   * @param names - Array of author names
+   * @returns Promise resolving to an array of Authors (same order as input)
+   */
+  findOrCreateMany(names: string[]): Promise<Author[]>;
+
+  /**
+   * Saves a new author to the persistence layer
+   *
+   * @param author - The author to save
+   * @returns Promise resolving to the saved Author
+   * @throws AuthorAlreadyExistsError if an author with the same name exists
+   */
+  save(author: Author): Promise<Author>;
+
+  /**
+   * Retrieves all authors
+   *
+   * @returns Promise resolving to an array of all Authors
+   */
+  findAll(): Promise<Author[]>;
+
+  /**
+   * Counts the total number of authors
+   *
+   * @returns Promise resolving to the total count
+   */
+  count(): Promise<number>;
+}

--- a/apps/api-cli/src/application/ports/index.ts
+++ b/apps/api-cli/src/application/ports/index.ts
@@ -16,5 +16,7 @@ export type {
 
 export type { CategoryRepository } from './CategoryRepository.js';
 
+export type { AuthorRepository } from './AuthorRepository.js';
+
 export type { Logger, LogContext, ChildLoggerOptions } from './Logger.js';
 export { noopLogger } from './Logger.js';

--- a/apps/api-cli/src/domain/errors/DomainErrors.ts
+++ b/apps/api-cli/src/domain/errors/DomainErrors.ts
@@ -46,6 +46,15 @@ export class CategoryAlreadyExistsError extends DomainError {
 }
 
 /**
+ * Thrown when trying to create an author with a name that already exists
+ */
+export class AuthorAlreadyExistsError extends DomainError {
+  constructor(name: string) {
+    super(`An author with name "${name}" already exists`);
+  }
+}
+
+/**
  * Thrown when trying to create a book with an ISBN that already exists
  * @deprecated Use DuplicateISBNError for ISBN duplicates or DuplicateBookError for triad duplicates
  */

--- a/apps/api-cli/src/domain/errors/index.ts
+++ b/apps/api-cli/src/domain/errors/index.ts
@@ -10,6 +10,7 @@ export {
   DuplicateBookError,
   CategoryNotFoundError,
   CategoryAlreadyExistsError,
+  AuthorAlreadyExistsError,
   RequiredFieldError,
   FieldTooLongError,
   InvalidUUIDError,

--- a/apps/api-cli/src/infrastructure/driven/persistence/PostgresAuthorRepository.ts
+++ b/apps/api-cli/src/infrastructure/driven/persistence/PostgresAuthorRepository.ts
@@ -1,0 +1,238 @@
+/**
+ * PostgresAuthorRepository Adapter
+ *
+ * Implements the AuthorRepository port using Drizzle ORM with PostgreSQL.
+ * This is a driven/output adapter in the hexagonal architecture.
+ */
+
+import { eq, inArray, sql } from 'drizzle-orm';
+import { Author } from '../../../domain/entities/Author.js';
+import { AuthorAlreadyExistsError } from '../../../domain/errors/DomainErrors.js';
+import type { AuthorRepository } from '../../../application/ports/AuthorRepository.js';
+import { authors, type AuthorSelect } from './drizzle/schema.js';
+import { AuthorMapper } from './mappers/AuthorMapper.js';
+import { generateUUID } from '../../../shared/utils/uuid.js';
+
+/**
+ * Database type that supports our operations
+ * This is a generic interface that works with any Drizzle PostgreSQL connection
+ */
+interface DrizzleDb {
+  select: () => {
+    from: (table: typeof authors) => {
+      where: (condition: unknown) => Promise<AuthorSelect[]>;
+    };
+  };
+  insert: (table: typeof authors) => {
+    values: (data: unknown) => {
+      returning: () => Promise<AuthorSelect[]>;
+      onConflictDoNothing: () => {
+        returning: () => Promise<AuthorSelect[]>;
+      };
+    };
+  };
+  query: {
+    authors: {
+      findFirst: (options?: { where?: unknown }) => Promise<AuthorSelect | null>;
+      findMany: (options?: { where?: unknown }) => Promise<AuthorSelect[]>;
+    };
+  };
+}
+
+/**
+ * PostgresAuthorRepository
+ *
+ * Adapter that implements AuthorRepository using Drizzle ORM.
+ * Provides CRUD operations for authors with unique name constraint.
+ */
+export class PostgresAuthorRepository implements AuthorRepository {
+  constructor(readonly db: DrizzleDb) {}
+
+  /**
+   * Finds an author by its unique identifier
+   */
+  async findById(id: string): Promise<Author | null> {
+    const result = await this.db.query.authors.findFirst({
+      where: eq(authors.id, id),
+    });
+
+    return result ? AuthorMapper.toDomain(result) : null;
+  }
+
+  /**
+   * Finds an author by its name (exact match)
+   */
+  async findByName(name: string): Promise<Author | null> {
+    const trimmedName = name.trim();
+    
+    const result = await this.db.query.authors.findFirst({
+      where: eq(authors.name, trimmedName),
+    });
+
+    return result ? AuthorMapper.toDomain(result) : null;
+  }
+
+  /**
+   * Finds multiple authors by their names
+   */
+  async findByNames(names: string[]): Promise<Author[]> {
+    if (names.length === 0) {
+      return [];
+    }
+
+    const trimmedNames = names.map((n) => n.trim());
+    
+    const results = await this.db.query.authors.findMany({
+      where: inArray(authors.name, trimmedNames),
+    });
+
+    return AuthorMapper.toDomainList(results);
+  }
+
+  /**
+   * Finds an author by name or creates it if it doesn't exist
+   */
+  async findOrCreate(name: string): Promise<Author> {
+    const existing = await this.findByName(name);
+    
+    if (existing) {
+      return existing;
+    }
+
+    // Create new author
+    const newAuthor = Author.create({
+      id: generateUUID(),
+      name: name,
+    });
+
+    try {
+      return await this.save(newAuthor);
+    } catch (error) {
+      // Handle concurrent creation: if another process created the author
+      // in between our check and save, return the existing one instead of
+      // propagating an AuthorAlreadyExistsError.
+      if (error instanceof AuthorAlreadyExistsError) {
+        const concurrentExisting = await this.findByName(name);
+        if (concurrentExisting) {
+          return concurrentExisting;
+        }
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Finds or creates multiple authors by their names
+   * Returns authors in the same order as input names
+   */
+  async findOrCreateMany(names: string[]): Promise<Author[]> {
+    if (names.length === 0) {
+      return [];
+    }
+
+    const trimmedNames = names.map((n) => n.trim());
+    
+    // Find existing authors
+    const existingAuthors = await this.findByNames(trimmedNames);
+    const existingNamesSet = new Set(existingAuthors.map((a) => a.name));
+
+    // Determine which authors need to be created
+    const namesToCreate = trimmedNames.filter((n) => !existingNamesSet.has(n));
+
+    // Create new authors if any
+    if (namesToCreate.length > 0) {
+      const authorsToInsert = namesToCreate.map((name) =>
+        Author.create({
+          id: generateUUID(),
+          name,
+        })
+      );
+
+      const insertRecords = AuthorMapper.toPersistenceList(authorsToInsert);
+      
+      // Insert with onConflictDoNothing - some may be skipped by concurrent writers
+      await this.db
+        .insert(authors)
+        .values(insertRecords)
+        .onConflictDoNothing()
+        .returning();
+    }
+
+    // Re-fetch all authors to ensure we have complete data
+    // This handles race conditions where concurrent writers inserted authors
+    // between our initial check and our insert attempt
+    const allAuthors = await this.findByNames(trimmedNames);
+    const authorMap = new Map(allAuthors.map((a) => [a.name, a]));
+
+    // Build result in input order and validate completeness
+    const result: Author[] = [];
+    for (const name of trimmedNames) {
+      const author = authorMap.get(name);
+      if (!author) {
+        const missingNames = trimmedNames.filter((n) => !authorMap.has(n));
+        throw new Error(
+          `Failed to find or create the requested authors: ${missingNames.join(', ')}`
+        );
+      }
+      result.push(author);
+    }
+
+    return result;
+  }
+
+  /**
+   * Saves a new author to the database
+   */
+  async save(author: Author): Promise<Author> {
+    const record = AuthorMapper.toPersistence(author);
+
+    try {
+      const result = await this.db
+        .insert(authors)
+        .values(record)
+        .returning();
+
+      const inserted = result[0];
+      if (!inserted) {
+        throw new Error('Failed to insert author - no record returned');
+      }
+
+      return AuthorMapper.toDomain(inserted);
+    } catch (error) {
+      if (this.isDuplicateKeyError(error)) {
+        throw new AuthorAlreadyExistsError(author.name);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Retrieves all authors
+   */
+  async findAll(): Promise<Author[]> {
+    const results = await this.db.query.authors.findMany();
+    return AuthorMapper.toDomainList(results);
+  }
+
+  /**
+   * Counts the total number of authors
+   */
+  async count(): Promise<number> {
+    const result = await this.db
+      .select()
+      .from(authors)
+      .where(sql`1=1`);
+    return result.length;
+  }
+
+  /**
+   * Checks if an error is a duplicate key violation
+   */
+  private isDuplicateKeyError(error: unknown): boolean {
+    if (error instanceof Error) {
+      return error.message.includes('duplicate key') ||
+             error.message.includes('unique constraint');
+    }
+    return false;
+  }
+}

--- a/apps/api-cli/src/infrastructure/driven/persistence/index.ts
+++ b/apps/api-cli/src/infrastructure/driven/persistence/index.ts
@@ -6,5 +6,6 @@
 
 export { PostgresCategoryRepository } from './PostgresCategoryRepository.js';
 export { PostgresBookRepository, normalizeForDuplicateCheck } from './PostgresBookRepository.js';
+export { PostgresAuthorRepository } from './PostgresAuthorRepository.js';
 export * from './drizzle/schema.js';
 export * from './mappers/index.js';

--- a/apps/api-cli/tests/integration/infrastructure/persistence/PostgresAuthorRepository.integration.test.ts
+++ b/apps/api-cli/tests/integration/infrastructure/persistence/PostgresAuthorRepository.integration.test.ts
@@ -1,0 +1,271 @@
+/**
+ * PostgresAuthorRepository Integration Tests
+ *
+ * Tests the AuthorRepository adapter against a real PostgreSQL database.
+ * Requires Docker containers to be running: docker-compose up -d
+ *
+ * Run with: npm run test:integration
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import pg from 'pg';
+import { PostgresAuthorRepository } from '../../../../src/infrastructure/driven/persistence/PostgresAuthorRepository.js';
+import { Author } from '../../../../src/domain/entities/Author.js';
+import { AuthorAlreadyExistsError } from '../../../../src/domain/errors/DomainErrors.js';
+import * as schema from '../../../../src/infrastructure/driven/persistence/drizzle/schema.js';
+import { generateUUID } from '../../../../src/shared/utils/uuid.js';
+
+const { Pool } = pg;
+const { authors, bookAuthors, books, bookCategories, categories } = schema;
+
+describe('PostgresAuthorRepository Integration', () => {
+  let pool: pg.Pool;
+  let db: ReturnType<typeof drizzle>;
+  let repository: PostgresAuthorRepository;
+
+  beforeAll(async () => {
+    const databaseUrl = process.env['DATABASE_URL'] ?? 'postgresql://library:library@localhost:5432/library';
+    
+    pool = new Pool({
+      connectionString: databaseUrl,
+      max: 5,
+    });
+
+    // Verify connection
+    const client = await pool.connect();
+    client.release();
+
+    db = drizzle(pool, { schema });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    repository = new PostgresAuthorRepository(db as any);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    // Clean up test data before each test (order matters due to FK constraints)
+    await db.delete(bookCategories);
+    await db.delete(bookAuthors);
+    await db.delete(books);
+    await db.delete(categories);
+    await db.delete(authors);
+  });
+
+  describe('save', () => {
+    it('should save a new author', async () => {
+      const author = Author.create({
+        id: generateUUID(),
+        name: 'Robert C. Martin',
+      });
+
+      const saved = await repository.save(author);
+
+      expect(saved.id).toBe(author.id);
+      expect(saved.name).toBe('Robert C. Martin');
+      expect(saved.createdAt).toBeInstanceOf(Date);
+      expect(saved.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it('should throw AuthorAlreadyExistsError for duplicate name', async () => {
+      const author1 = Author.create({
+        id: generateUUID(),
+        name: 'Duplicate Author',
+      });
+
+      await repository.save(author1);
+
+      const author2 = Author.create({
+        id: generateUUID(),
+        name: 'Duplicate Author', // Same name
+      });
+
+      await expect(repository.save(author2))
+        .rejects
+        .toThrow(AuthorAlreadyExistsError);
+    });
+  });
+
+  describe('findById', () => {
+    it('should find an existing author by ID', async () => {
+      const author = Author.create({
+        id: generateUUID(),
+        name: 'Martin Fowler',
+      });
+      await repository.save(author);
+
+      const found = await repository.findById(author.id);
+
+      expect(found).not.toBeNull();
+      expect(found!.id).toBe(author.id);
+      expect(found!.name).toBe('Martin Fowler');
+    });
+
+    it('should return null for non-existent ID', async () => {
+      const found = await repository.findById(generateUUID());
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('findByName', () => {
+    it('should find author by exact name', async () => {
+      const author = Author.create({
+        id: generateUUID(),
+        name: 'Kent Beck',
+      });
+      await repository.save(author);
+
+      const found = await repository.findByName('Kent Beck');
+
+      expect(found).not.toBeNull();
+      expect(found!.name).toBe('Kent Beck');
+    });
+
+    it('should not find author with different case (case-sensitive)', async () => {
+      const author = Author.create({
+        id: generateUUID(),
+        name: 'Kent Beck',
+      });
+      await repository.save(author);
+
+      // Authors use exact matching (case-sensitive) unlike categories
+      const found = await repository.findByName('KENT BECK');
+      expect(found).toBeNull();
+    });
+
+    it('should return null for non-existent name', async () => {
+      const found = await repository.findByName('Non-existent Author');
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('findByNames', () => {
+    it('should find multiple authors by names', async () => {
+      await repository.save(Author.create({ id: generateUUID(), name: 'Author A' }));
+      await repository.save(Author.create({ id: generateUUID(), name: 'Author B' }));
+      await repository.save(Author.create({ id: generateUUID(), name: 'Author C' }));
+
+      const found = await repository.findByNames(['Author A', 'Author C']);
+
+      expect(found).toHaveLength(2);
+      const names = found.map((a) => a.name);
+      expect(names).toContain('Author A');
+      expect(names).toContain('Author C');
+    });
+
+    it('should return empty array for empty input', async () => {
+      const found = await repository.findByNames([]);
+      expect(found).toEqual([]);
+    });
+
+    it('should return only existing authors', async () => {
+      await repository.save(Author.create({ id: generateUUID(), name: 'Exists' }));
+
+      const found = await repository.findByNames(['Exists', 'Does Not Exist']);
+
+      expect(found).toHaveLength(1);
+      expect(found[0]!.name).toBe('Exists');
+    });
+  });
+
+  describe('findOrCreate', () => {
+    it('should return existing author if found', async () => {
+      const existing = await repository.save(
+        Author.create({ id: generateUUID(), name: 'Existing Author' })
+      );
+
+      const result = await repository.findOrCreate('Existing Author');
+
+      expect(result.id).toBe(existing.id);
+      expect(result.name).toBe('Existing Author');
+    });
+
+    it('should create new author if not found', async () => {
+      const result = await repository.findOrCreate('Brand New Author');
+
+      expect(result.name).toBe('Brand New Author');
+      expect(result.id).toBeDefined();
+
+      // Verify it was persisted
+      const verified = await repository.findByName('Brand New Author');
+      expect(verified).not.toBeNull();
+      expect(verified!.id).toBe(result.id);
+    });
+  });
+
+  describe('findOrCreateMany', () => {
+    it('should find existing and create new authors', async () => {
+      // Create one existing author
+      await repository.save(
+        Author.create({ id: generateUUID(), name: 'Existing' })
+      );
+
+      const result = await repository.findOrCreateMany(['Existing', 'New One', 'New Two']);
+
+      expect(result).toHaveLength(3);
+      expect(result[0]!.name).toBe('Existing');
+      expect(result[1]!.name).toBe('New One');
+      expect(result[2]!.name).toBe('New Two');
+    });
+
+    it('should maintain input order in results', async () => {
+      await repository.save(Author.create({ id: generateUUID(), name: 'Zebra' }));
+      await repository.save(Author.create({ id: generateUUID(), name: 'Apple' }));
+
+      const result = await repository.findOrCreateMany(['Apple', 'Zebra', 'Mango']);
+
+      expect(result[0]!.name).toBe('Apple');
+      expect(result[1]!.name).toBe('Zebra');
+      expect(result[2]!.name).toBe('Mango');
+    });
+
+    it('should return empty array for empty input', async () => {
+      const result = await repository.findOrCreateMany([]);
+      expect(result).toEqual([]);
+    });
+
+    it('should handle duplicates in input', async () => {
+      const result = await repository.findOrCreateMany(['Same', 'Same', 'Same']);
+
+      // Should return 3 items, all pointing to the same author
+      expect(result).toHaveLength(3);
+      expect(result[0]!.id).toBe(result[1]!.id);
+      expect(result[1]!.id).toBe(result[2]!.id);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all authors', async () => {
+      await repository.save(Author.create({ id: generateUUID(), name: 'First' }));
+      await repository.save(Author.create({ id: generateUUID(), name: 'Second' }));
+
+      const all = await repository.findAll();
+
+      expect(all).toHaveLength(2);
+    });
+
+    it('should return empty array when no authors exist', async () => {
+      const all = await repository.findAll();
+      expect(all).toEqual([]);
+    });
+  });
+
+  describe('count', () => {
+    it('should return the correct count of authors', async () => {
+      await repository.save(Author.create({ id: generateUUID(), name: 'Author 1' }));
+      await repository.save(Author.create({ id: generateUUID(), name: 'Author 2' }));
+      await repository.save(Author.create({ id: generateUUID(), name: 'Author 3' }));
+
+      const count = await repository.count();
+
+      expect(count).toBe(3);
+    });
+
+    it('should return 0 when no authors exist', async () => {
+      const count = await repository.count();
+      expect(count).toBe(0);
+    });
+  });
+});

--- a/apps/api-cli/tests/unit/infrastructure/driven/persistence/PostgresAuthorRepository.test.ts
+++ b/apps/api-cli/tests/unit/infrastructure/driven/persistence/PostgresAuthorRepository.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PostgresAuthorRepository } from '../../../../../src/infrastructure/driven/persistence/PostgresAuthorRepository.js';
+import { Author } from '../../../../../src/domain/entities/Author.js';
+import { AuthorAlreadyExistsError } from '../../../../../src/domain/errors/DomainErrors.js';
+import type { AuthorSelect } from '../../../../../src/infrastructure/driven/persistence/drizzle/schema.js';
+
+// Mock Drizzle database
+type MockDb = {
+  select: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  query: {
+    authors: {
+      findFirst: ReturnType<typeof vi.fn>;
+      findMany: ReturnType<typeof vi.fn>;
+    };
+  };
+};
+
+describe('PostgresAuthorRepository', () => {
+  let mockDb: MockDb;
+  let repository: PostgresAuthorRepository;
+
+  // Sample database records
+  const mockAuthorRecord: AuthorSelect = {
+    id: '550e8400-e29b-41d4-a716-446655440001',
+    name: 'Robert C. Martin',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  };
+
+  const mockAuthorRecord2: AuthorSelect = {
+    id: '550e8400-e29b-41d4-a716-446655440002',
+    name: 'Martin Fowler',
+    createdAt: new Date('2026-01-02T00:00:00Z'),
+    updatedAt: new Date('2026-01-02T00:00:00Z'),
+  };
+
+  beforeEach(() => {
+    // Create mock database with chained query builder pattern
+    const createChainedMock = (result: unknown) => {
+      const chain = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        values: vi.fn().mockReturnThis(),
+        onConflictDoNothing: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue(result),
+        then: vi.fn((resolve) => Promise.resolve(result).then(resolve)),
+      };
+      return vi.fn().mockReturnValue(chain);
+    };
+
+    mockDb = {
+      select: createChainedMock([]),
+      insert: createChainedMock([]),
+      query: {
+        authors: {
+          findFirst: vi.fn(),
+          findMany: vi.fn(),
+        },
+      },
+    };
+
+    repository = new PostgresAuthorRepository(mockDb as unknown as PostgresAuthorRepository['db']);
+  });
+
+  describe('findById', () => {
+    it('should return author when found', async () => {
+      mockDb.query.authors.findFirst.mockResolvedValue(mockAuthorRecord);
+
+      const result = await repository.findById(mockAuthorRecord.id);
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(mockAuthorRecord.id);
+      expect(result?.name).toBe('Robert C. Martin');
+    });
+
+    it('should return null when not found', async () => {
+      mockDb.query.authors.findFirst.mockResolvedValue(null);
+
+      const result = await repository.findById('nonexistent-id');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findByName', () => {
+    it('should find author by exact name', async () => {
+      mockDb.query.authors.findFirst.mockResolvedValue(mockAuthorRecord);
+
+      const result = await repository.findByName('Robert C. Martin');
+
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('Robert C. Martin');
+    });
+
+    it('should trim whitespace from name', async () => {
+      mockDb.query.authors.findFirst.mockResolvedValue(mockAuthorRecord);
+
+      await repository.findByName('  Robert C. Martin  ');
+
+      expect(mockDb.query.authors.findFirst).toHaveBeenCalled();
+    });
+
+    it('should return null when not found', async () => {
+      mockDb.query.authors.findFirst.mockResolvedValue(null);
+
+      const result = await repository.findByName('nonexistent');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findByNames', () => {
+    it('should find multiple authors by names', async () => {
+      mockDb.query.authors.findMany.mockResolvedValue([
+        mockAuthorRecord,
+        mockAuthorRecord2,
+      ]);
+
+      const result = await repository.findByNames(['Robert C. Martin', 'Martin Fowler']);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('should return empty array when no names provided', async () => {
+      const result = await repository.findByNames([]);
+
+      expect(result).toEqual([]);
+      expect(mockDb.query.authors.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should return only found authors', async () => {
+      mockDb.query.authors.findMany.mockResolvedValue([mockAuthorRecord]);
+
+      const result = await repository.findByNames(['Robert C. Martin', 'nonexistent']);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Robert C. Martin');
+    });
+  });
+
+  describe('findOrCreate', () => {
+    it('should return existing author if found', async () => {
+      mockDb.query.authors.findFirst.mockResolvedValue(mockAuthorRecord);
+
+      const result = await repository.findOrCreate('Robert C. Martin');
+
+      expect(result.id).toBe(mockAuthorRecord.id);
+      expect(result.name).toBe('Robert C. Martin');
+    });
+
+    it('should create new author if not found', async () => {
+      mockDb.query.authors.findFirst.mockResolvedValue(null);
+
+      const insertChain = {
+        values: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([{
+          id: '550e8400-e29b-41d4-a716-446655440099',
+          name: 'New Author',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }]),
+      };
+      mockDb.insert.mockReturnValue(insertChain);
+
+      const result = await repository.findOrCreate('New Author');
+
+      expect(result.name).toBe('New Author');
+    });
+
+    it('should handle concurrent creation gracefully', async () => {
+      // First check returns null (author doesn't exist)
+      mockDb.query.authors.findFirst
+        .mockResolvedValueOnce(null)
+        // Second check (after insert fails) returns existing author
+        .mockResolvedValueOnce(mockAuthorRecord);
+
+      const insertChain = {
+        values: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockRejectedValue(new Error('duplicate key value violates unique constraint')),
+      };
+      mockDb.insert.mockReturnValue(insertChain);
+
+      const result = await repository.findOrCreate('Robert C. Martin');
+
+      expect(result.name).toBe('Robert C. Martin');
+    });
+  });
+
+  describe('findOrCreateMany', () => {
+    it('should find existing and create new authors', async () => {
+      const newAuthorRecord: AuthorSelect = {
+        id: '550e8400-e29b-41d4-a716-446655440099',
+        name: 'New Author',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      // First findByNames call - only existing authors
+      mockDb.query.authors.findMany.mockResolvedValueOnce([mockAuthorRecord]);
+
+      // Insert new ones
+      const insertChain = {
+        values: vi.fn().mockReturnThis(),
+        onConflictDoNothing: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([newAuthorRecord]),
+      };
+      mockDb.insert.mockReturnValue(insertChain);
+
+      // Second findByNames call after insert - all authors
+      mockDb.query.authors.findMany.mockResolvedValueOnce([
+        mockAuthorRecord,
+        newAuthorRecord,
+      ]);
+
+      const result = await repository.findOrCreateMany(['Robert C. Martin', 'New Author']);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('Robert C. Martin');
+      expect(result[1].name).toBe('New Author');
+    });
+
+    it('should return empty array for empty input', async () => {
+      const result = await repository.findOrCreateMany([]);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should maintain order of input names', async () => {
+      // First call - all already exist
+      mockDb.query.authors.findMany.mockResolvedValueOnce([
+        mockAuthorRecord2, // Martin Fowler
+        mockAuthorRecord,  // Robert C. Martin
+      ]);
+
+      // Second call after insert (no insert needed) - same data
+      mockDb.query.authors.findMany.mockResolvedValueOnce([
+        mockAuthorRecord2,
+        mockAuthorRecord,
+      ]);
+
+      const result = await repository.findOrCreateMany(['Robert C. Martin', 'Martin Fowler']);
+
+      // Should be in input order, not DB return order
+      expect(result[0].name).toBe('Robert C. Martin');
+      expect(result[1].name).toBe('Martin Fowler');
+    });
+
+    it('should handle race condition where concurrent writer inserts author', async () => {
+      const concurrentAuthorRecord: AuthorSelect = {
+        id: '550e8400-e29b-41d4-a716-446655440099',
+        name: 'Concurrent Author',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      // First findByNames - author doesn't exist yet
+      mockDb.query.authors.findMany.mockResolvedValueOnce([]);
+
+      // Insert attempt with onConflictDoNothing - returns empty because concurrent writer won
+      const insertChain = {
+        values: vi.fn().mockReturnThis(),
+        onConflictDoNothing: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([]), // Empty - conflict occurred
+      };
+      mockDb.insert.mockReturnValue(insertChain);
+
+      // Second findByNames after insert - now the author exists (inserted by concurrent writer)
+      mockDb.query.authors.findMany.mockResolvedValueOnce([concurrentAuthorRecord]);
+
+      const result = await repository.findOrCreateMany(['Concurrent Author']);
+
+      // Should successfully return the author despite the race condition
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Concurrent Author');
+      expect(result[0].id).toBe(concurrentAuthorRecord.id);
+    });
+
+    it('should throw error if authors cannot be found or created', async () => {
+      // First findByNames - author doesn't exist
+      mockDb.query.authors.findMany.mockResolvedValueOnce([]);
+
+      // Insert attempt fails
+      const insertChain = {
+        values: vi.fn().mockReturnThis(),
+        onConflictDoNothing: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([]),
+      };
+      mockDb.insert.mockReturnValue(insertChain);
+
+      // Second findByNames after insert - still doesn't exist (unexpected situation)
+      mockDb.query.authors.findMany.mockResolvedValueOnce([]);
+
+      await expect(repository.findOrCreateMany(['missing author']))
+        .rejects.toThrow('Failed to find or create the requested authors: missing author');
+    });
+  });
+
+  describe('save', () => {
+    it('should save a new author', async () => {
+      const newAuthor = Author.create({
+        id: '550e8400-e29b-41d4-a716-446655440099',
+        name: 'New Author',
+      });
+
+      const insertChain = {
+        values: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([{
+          id: newAuthor.id,
+          name: newAuthor.name,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }]),
+      };
+      mockDb.insert.mockReturnValue(insertChain);
+
+      const result = await repository.save(newAuthor);
+
+      expect(result.id).toBe(newAuthor.id);
+    });
+
+    it('should throw AuthorAlreadyExistsError on duplicate', async () => {
+      const duplicateAuthor = Author.create({
+        id: '550e8400-e29b-41d4-a716-446655440099',
+        name: 'Robert C. Martin', // Already exists
+      });
+
+      const insertChain = {
+        values: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockRejectedValue(new Error('duplicate key value violates unique constraint')),
+      };
+      mockDb.insert.mockReturnValue(insertChain);
+
+      await expect(repository.save(duplicateAuthor)).rejects.toThrow(AuthorAlreadyExistsError);
+    });
+
+    it('should throw error when insert returns no record', async () => {
+      const newAuthor = Author.create({
+        id: '550e8400-e29b-41d4-a716-446655440099',
+        name: 'New Author',
+      });
+
+      const insertChain = {
+        values: vi.fn().mockReturnThis(),
+        returning: vi.fn().mockResolvedValue([]),
+      };
+      mockDb.insert.mockReturnValue(insertChain);
+
+      await expect(repository.save(newAuthor)).rejects.toThrow('Failed to insert author - no record returned');
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all authors', async () => {
+      mockDb.query.authors.findMany.mockResolvedValue([
+        mockAuthorRecord,
+        mockAuthorRecord2,
+      ]);
+
+      const result = await repository.findAll();
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('should return empty array when no authors', async () => {
+      mockDb.query.authors.findMany.mockResolvedValue([]);
+
+      const result = await repository.findAll();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('count', () => {
+    it('should return the count of authors', async () => {
+      const selectChain = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([mockAuthorRecord, mockAuthorRecord2]),
+      };
+      mockDb.select.mockReturnValue(selectChain);
+
+      const result = await repository.count();
+
+      expect(result).toBe(2);
+    });
+
+    it('should return 0 when no authors', async () => {
+      const selectChain = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([]),
+      };
+      mockDb.select.mockReturnValue(selectChain);
+
+      const result = await repository.count();
+
+      expect(result).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement `AuthorRepository` port interface for managing authors with N:M relationship to books
- Add `PostgresAuthorRepository` adapter using Drizzle ORM with atomic `findOrCreate` operations

## Changes

### New Files
- `src/application/ports/AuthorRepository.ts` - Port interface defining:
  - `findById`, `findByName`, `findByNames`
  - `findOrCreate`, `findOrCreateMany` (atomic operations)
  - `save`, `findAll`, `count`

- `src/infrastructure/driven/persistence/PostgresAuthorRepository.ts` - Adapter implementing:
  - Exact name matching for author lookups
  - Concurrent creation handling with retry logic
  - `onConflictDoNothing` for batch inserts

### Updated Files
- `src/domain/errors/DomainErrors.ts` - Added `AuthorAlreadyExistsError`
- `src/domain/errors/index.ts` - Export new error
- `src/application/ports/index.ts` - Export `AuthorRepository`
- `src/infrastructure/driven/persistence/index.ts` - Export `PostgresAuthorRepository`

### Tests
| Type | Count |
|------|-------|
| Unit | 23 |
| Integration | 20 |

**Total tests now passing:**
- Unit: 414 (+23)
- Integration: 69 (+20)

## Part of
TASK-007 for HU-002 (Initial Data Load)