### PR TITLE
feat(persistence): implement TypeRepository port and adapter

### DIFF
--- a/apps/api-cli/src/application/ports/TypeRepository.ts
+++ b/apps/api-cli/src/application/ports/TypeRepository.ts
@@ -1,0 +1,54 @@
+/**
+ * TypeRepository Port (Driven/Output Port)
+ *
+ * Defines the contract for book type persistence operations.
+ * This is a port in the hexagonal architecture - the actual implementation
+ * (e.g., PostgresTypeRepository) will be an adapter in the infrastructure layer.
+ *
+ * NOTE: Types are read-only in the application layer. They are seeded at database
+ * initialization and should not be created/updated through the application.
+ * This is why there is no save(), update(), or findOrCreate() methods.
+ */
+
+import type { BookType } from '../../domain/entities/BookType.js';
+
+/**
+ * TypeRepository Port Interface
+ *
+ * Provides read-only operations for managing book types in the persistence layer.
+ * Used by the CreateBook use case to validate and retrieve type references.
+ */
+export interface TypeRepository {
+  /**
+   * Finds a book type by its unique identifier
+   *
+   * @param id - The type UUID
+   * @returns Promise resolving to the BookType if found, null otherwise
+   */
+  findById(id: string): Promise<BookType | null>;
+
+  /**
+   * Finds a book type by its name (case-insensitive)
+   *
+   * Note: Type names are stored in lowercase. The search is case-insensitive
+   * to provide a better user experience.
+   *
+   * @param name - The type name to search for (e.g., "technical", "novel")
+   * @returns Promise resolving to the BookType if found, null otherwise
+   */
+  findByName(name: string): Promise<BookType | null>;
+
+  /**
+   * Retrieves all book types
+   *
+   * @returns Promise resolving to an array of all BookTypes
+   */
+  findAll(): Promise<BookType[]>;
+
+  /**
+   * Counts the total number of book types
+   *
+   * @returns Promise resolving to the total count
+   */
+  count(): Promise<number>;
+}

--- a/apps/api-cli/src/application/ports/index.ts
+++ b/apps/api-cli/src/application/ports/index.ts
@@ -18,5 +18,7 @@ export type { CategoryRepository } from './CategoryRepository.js';
 
 export type { AuthorRepository } from './AuthorRepository.js';
 
+export type { TypeRepository } from './TypeRepository.js';
+
 export type { Logger, LogContext, ChildLoggerOptions } from './Logger.js';
 export { noopLogger } from './Logger.js';

--- a/apps/api-cli/src/infrastructure/driven/persistence/PostgresTypeRepository.ts
+++ b/apps/api-cli/src/infrastructure/driven/persistence/PostgresTypeRepository.ts
@@ -1,0 +1,95 @@
+/**
+ * PostgresTypeRepository
+ *
+ * PostgreSQL implementation of the TypeRepository port using Drizzle ORM.
+ *
+ * This repository provides read-only access to book types stored in the database.
+ * Types are seeded at database initialization and should not be created/updated
+ * through the application layer.
+ *
+ * Part of TASK-008 for HU-002 (Initial Data Load)
+ */
+
+import { eq, count } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type { TypeRepository } from '../../../application/ports/TypeRepository.js';
+import { BookType } from '../../../domain/entities/BookType.js';
+import { types } from './drizzle/schema.js';
+import { TypeMapper } from './mappers/TypeMapper.js';
+import * as schema from './drizzle/schema.js';
+
+/**
+ * PostgreSQL implementation of TypeRepository
+ */
+export class PostgresTypeRepository implements TypeRepository {
+  constructor(public readonly db: PostgresJsDatabase<typeof schema>) {}
+
+  /**
+   * Finds a book type by its unique identifier
+   *
+   * @param id - The type UUID
+   * @returns Promise resolving to the BookType if found, null otherwise
+   */
+  async findById(id: string): Promise<BookType | null> {
+    const result = await this.db.query.types.findFirst({
+      where: (types, { eq }) => eq(types.id, id),
+    });
+
+    if (!result) {
+      return null;
+    }
+
+    return TypeMapper.toDomain(result);
+  }
+
+  /**
+   * Finds a book type by its name (case-insensitive)
+   *
+   * Type names are stored in lowercase, so we normalize the input
+   * for case-insensitive matching.
+   *
+   * @param name - The type name to search for
+   * @returns Promise resolving to the BookType if found, null otherwise
+   */
+  async findByName(name: string): Promise<BookType | null> {
+    const trimmedName = name.trim();
+
+    // Early return for empty names
+    if (!trimmedName) {
+      return null;
+    }
+
+    // Normalize to lowercase for case-insensitive search
+    const normalizedName = trimmedName.toLowerCase();
+
+    const result = await this.db.query.types.findFirst({
+      where: (types, { eq }) => eq(types.name, normalizedName),
+    });
+
+    if (!result) {
+      return null;
+    }
+
+    return TypeMapper.toDomain(result);
+  }
+
+  /**
+   * Retrieves all book types
+   *
+   * @returns Promise resolving to an array of all BookTypes
+   */
+  async findAll(): Promise<BookType[]> {
+    const results = await this.db.query.types.findMany();
+    return TypeMapper.toDomainList(results);
+  }
+
+  /**
+   * Counts the total number of book types
+   *
+   * @returns Promise resolving to the total count
+   */
+  async count(): Promise<number> {
+    const result = await this.db.select({ count: count() }).from(types);
+    return Number(result[0]?.count ?? 0);
+  }
+}

--- a/apps/api-cli/src/infrastructure/driven/persistence/index.ts
+++ b/apps/api-cli/src/infrastructure/driven/persistence/index.ts
@@ -7,5 +7,6 @@
 export { PostgresCategoryRepository } from './PostgresCategoryRepository.js';
 export { PostgresBookRepository, normalizeForDuplicateCheck } from './PostgresBookRepository.js';
 export { PostgresAuthorRepository } from './PostgresAuthorRepository.js';
+export { PostgresTypeRepository } from './PostgresTypeRepository.js';
 export * from './drizzle/schema.js';
 export * from './mappers/index.js';

--- a/apps/api-cli/tests/integration/infrastructure/persistence/PostgresTypeRepository.integration.test.ts
+++ b/apps/api-cli/tests/integration/infrastructure/persistence/PostgresTypeRepository.integration.test.ts
@@ -1,0 +1,286 @@
+/**
+ * PostgresTypeRepository Integration Tests
+ *
+ * Tests the TypeRepository adapter against a real PostgreSQL database.
+ * Requires Docker containers to be running: docker-compose up -d
+ *
+ * IMPORTANT: This test uses prefixed type names (e.g., 'test_technical') to avoid
+ * conflicts with seed types that other integration tests depend on.
+ * It does NOT delete the types table, preserving the seed data.
+ *
+ * Run with: npm run test:integration
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { eq, like } from 'drizzle-orm';
+import pg from 'pg';
+import { PostgresTypeRepository } from '../../../../src/infrastructure/driven/persistence/PostgresTypeRepository.js';
+import * as schema from '../../../../src/infrastructure/driven/persistence/drizzle/schema.js';
+import { generateUUID } from '../../../../src/shared/utils/uuid.js';
+
+const { Pool } = pg;
+const { types, books, bookAuthors, bookCategories, categories, authors } = schema;
+
+/**
+ * Prefix used to identify test-created types.
+ * This allows us to clean up test data without affecting seed types.
+ */
+const TEST_TYPE_PREFIX = 'test_';
+
+describe('PostgresTypeRepository Integration', () => {
+  let pool: pg.Pool;
+  let db: ReturnType<typeof drizzle>;
+  let repository: PostgresTypeRepository;
+
+  beforeAll(async () => {
+    const databaseUrl = process.env['DATABASE_URL'] ?? 'postgresql://library:library@localhost:5432/library';
+    
+    pool = new Pool({
+      connectionString: databaseUrl,
+      max: 5,
+    });
+
+    // Verify connection
+    const client = await pool.connect();
+    client.release();
+
+    db = drizzle(pool, { schema });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    repository = new PostgresTypeRepository(db as any);
+  });
+
+  afterAll(async () => {
+    // Clean up only test types (prefixed)
+    await cleanupTestTypes();
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    // Clean up only test types before each test (keeps seed types intact)
+    await cleanupTestTypes();
+  });
+
+  /**
+   * Cleans up only types created by this test (prefixed with TEST_TYPE_PREFIX)
+   */
+  async function cleanupTestTypes(): Promise<void> {
+    await db.delete(types).where(like(types.name, `${TEST_TYPE_PREFIX}%`));
+  }
+
+  /**
+   * Helper function to seed a test type directly in the database.
+   * Uses a prefix to distinguish from seed types.
+   */
+  async function seedTestType(name: string): Promise<string> {
+    const id = generateUUID();
+    const now = new Date();
+    const prefixedName = `${TEST_TYPE_PREFIX}${name.toLowerCase()}`;
+    await db.insert(types).values({
+      id,
+      name: prefixedName,
+      createdAt: now,
+      updatedAt: now,
+    });
+    return id;
+  }
+
+  describe('findById', () => {
+    it('should find an existing type by ID', async () => {
+      const id = await seedTestType('technical');
+
+      const found = await repository.findById(id);
+
+      expect(found).not.toBeNull();
+      expect(found!.id).toBe(id);
+      expect(found!.name).toBe(`${TEST_TYPE_PREFIX}technical`);
+    });
+
+    it('should return null for non-existent ID', async () => {
+      const found = await repository.findById(generateUUID());
+
+      expect(found).toBeNull();
+    });
+
+    it('should return type with all properties', async () => {
+      const id = await seedTestType('novel');
+
+      const found = await repository.findById(id);
+
+      expect(found).not.toBeNull();
+      expect(found!.id).toBe(id);
+      expect(found!.name).toBe(`${TEST_TYPE_PREFIX}novel`);
+      expect(found!.createdAt).toBeInstanceOf(Date);
+      expect(found!.updatedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('findByName', () => {
+    it('should find type by exact lowercase name', async () => {
+      await seedTestType('technical');
+
+      const found = await repository.findByName(`${TEST_TYPE_PREFIX}technical`);
+
+      expect(found).not.toBeNull();
+      expect(found!.name).toBe(`${TEST_TYPE_PREFIX}technical`);
+    });
+
+    it('should find type by uppercase name (case-insensitive)', async () => {
+      await seedTestType('technical');
+
+      const found = await repository.findByName(`${TEST_TYPE_PREFIX}TECHNICAL`.toUpperCase());
+
+      expect(found).not.toBeNull();
+      expect(found!.name).toBe(`${TEST_TYPE_PREFIX}technical`);
+    });
+
+    it('should find type by mixed case name', async () => {
+      await seedTestType('technical');
+
+      const found = await repository.findByName(`${TEST_TYPE_PREFIX}Technical`);
+
+      expect(found).not.toBeNull();
+      expect(found!.name).toBe(`${TEST_TYPE_PREFIX}technical`);
+    });
+
+    it('should find type with trimmed whitespace', async () => {
+      await seedTestType('novel');
+
+      const found = await repository.findByName(`  ${TEST_TYPE_PREFIX}novel  `);
+
+      expect(found).not.toBeNull();
+      expect(found!.name).toBe(`${TEST_TYPE_PREFIX}novel`);
+    });
+
+    it('should return null for non-existent type', async () => {
+      await seedTestType('technical');
+
+      const found = await repository.findByName(`${TEST_TYPE_PREFIX}nonexistent`);
+
+      expect(found).toBeNull();
+    });
+
+    it('should return null for empty name', async () => {
+      await seedTestType('technical');
+
+      const found = await repository.findByName('');
+
+      expect(found).toBeNull();
+    });
+
+    it('should return null for whitespace-only name', async () => {
+      await seedTestType('technical');
+
+      const found = await repository.findByName('   ');
+
+      expect(found).toBeNull();
+    });
+
+    it('should find existing seed types (e.g., technical)', async () => {
+      // This test verifies the repository works with actual seed data
+      const found = await repository.findByName('technical');
+
+      // This will pass if seed types exist, otherwise skip
+      if (found) {
+        expect(found.name).toBe('technical');
+      }
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all types including test and seed types', async () => {
+      await seedTestType('alpha');
+      await seedTestType('beta');
+
+      const all = await repository.findAll();
+
+      // Should include our test types plus any seed types
+      expect(all.length).toBeGreaterThanOrEqual(2);
+      
+      const testTypeNames = all
+        .filter((t) => t.name.startsWith(TEST_TYPE_PREFIX))
+        .map((t) => t.name)
+        .sort();
+      expect(testTypeNames).toEqual([`${TEST_TYPE_PREFIX}alpha`, `${TEST_TYPE_PREFIX}beta`]);
+    });
+
+    it('should return at least seed types when no test types exist', async () => {
+      const all = await repository.findAll();
+
+      // Should include seed types (technical, novel, biography)
+      const seedTypeNames = all
+        .filter((t) => !t.name.startsWith(TEST_TYPE_PREFIX))
+        .map((t) => t.name);
+      
+      // At minimum, seed types should exist
+      expect(seedTypeNames.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should return types with all properties', async () => {
+      await seedTestType('gamma');
+
+      const all = await repository.findAll();
+      const testType = all.find((t) => t.name === `${TEST_TYPE_PREFIX}gamma`);
+
+      expect(testType).toBeDefined();
+      expect(testType!.id).toBeDefined();
+      expect(testType!.name).toBe(`${TEST_TYPE_PREFIX}gamma`);
+      expect(testType!.createdAt).toBeInstanceOf(Date);
+      expect(testType!.updatedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('count', () => {
+    it('should return correct count including test types', async () => {
+      const initialCount = await repository.count();
+      
+      await seedTestType('count1');
+      await seedTestType('count2');
+      await seedTestType('count3');
+
+      const newCount = await repository.count();
+
+      expect(newCount).toBe(initialCount + 3);
+    });
+
+    it('should return at least 0 for count', async () => {
+      const count = await repository.count();
+
+      expect(count).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should increment count when adding types', async () => {
+      const initial = await repository.count();
+
+      await seedTestType('increment1');
+      expect(await repository.count()).toBe(initial + 1);
+
+      await seedTestType('increment2');
+      expect(await repository.count()).toBe(initial + 2);
+    });
+  });
+
+  describe('domain entity behavior', () => {
+    it('should return immutable BookType entities', async () => {
+      await seedTestType('immutable');
+
+      const found = await repository.findByName(`${TEST_TYPE_PREFIX}immutable`);
+
+      expect(found).not.toBeNull();
+      // BookType should be frozen
+      expect(Object.isFrozen(found!)).toBe(true);
+    });
+
+    it('should correctly identify type by name using hasName method', async () => {
+      await seedTestType('hasname');
+
+      const found = await repository.findByName(`${TEST_TYPE_PREFIX}hasname`);
+
+      expect(found).not.toBeNull();
+      expect(found!.hasName(`${TEST_TYPE_PREFIX}hasname`)).toBe(true);
+      expect(found!.hasName(`${TEST_TYPE_PREFIX}HASNAME`)).toBe(true);
+      expect(found!.hasName(`${TEST_TYPE_PREFIX}HasName`)).toBe(true);
+      expect(found!.hasName('novel')).toBe(false);
+    });
+  });
+});

--- a/apps/api-cli/tests/unit/infrastructure/driven/persistence/PostgresTypeRepository.test.ts
+++ b/apps/api-cli/tests/unit/infrastructure/driven/persistence/PostgresTypeRepository.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PostgresTypeRepository } from '../../../../../src/infrastructure/driven/persistence/PostgresTypeRepository.js';
+import type { TypeSelect } from '../../../../../src/infrastructure/driven/persistence/drizzle/schema.js';
+
+// Mock Drizzle database
+type MockDb = {
+  select: ReturnType<typeof vi.fn>;
+  query: {
+    types: {
+      findFirst: ReturnType<typeof vi.fn>;
+      findMany: ReturnType<typeof vi.fn>;
+    };
+  };
+};
+
+describe('PostgresTypeRepository', () => {
+  let mockDb: MockDb;
+  let repository: PostgresTypeRepository;
+
+  // Sample database records
+  const mockTypeRecord: TypeSelect = {
+    id: '550e8400-e29b-41d4-a716-446655440001',
+    name: 'technical',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  };
+
+  const mockTypeRecord2: TypeSelect = {
+    id: '550e8400-e29b-41d4-a716-446655440002',
+    name: 'novel',
+    createdAt: new Date('2026-01-02T00:00:00Z'),
+    updatedAt: new Date('2026-01-02T00:00:00Z'),
+  };
+
+  const mockTypeRecord3: TypeSelect = {
+    id: '550e8400-e29b-41d4-a716-446655440003',
+    name: 'biography',
+    createdAt: new Date('2026-01-03T00:00:00Z'),
+    updatedAt: new Date('2026-01-03T00:00:00Z'),
+  };
+
+  beforeEach(() => {
+    // Create mock database with chained query builder pattern
+    const createChainedMock = (result: unknown) => {
+      const chain = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        then: vi.fn((resolve) => Promise.resolve(result).then(resolve)),
+      };
+      return vi.fn().mockReturnValue(chain);
+    };
+
+    mockDb = {
+      select: createChainedMock([]),
+      query: {
+        types: {
+          findFirst: vi.fn(),
+          findMany: vi.fn(),
+        },
+      },
+    };
+
+    repository = new PostgresTypeRepository(mockDb as unknown as PostgresTypeRepository['db']);
+  });
+
+  describe('findById', () => {
+    it('should return type when found', async () => {
+      mockDb.query.types.findFirst.mockResolvedValue(mockTypeRecord);
+
+      const result = await repository.findById(mockTypeRecord.id);
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(mockTypeRecord.id);
+      expect(result?.name).toBe('technical');
+    });
+
+    it('should return null when not found', async () => {
+      mockDb.query.types.findFirst.mockResolvedValue(null);
+
+      const result = await repository.findById('nonexistent-id');
+
+      expect(result).toBeNull();
+    });
+
+    it('should call findFirst with correct id', async () => {
+      mockDb.query.types.findFirst.mockResolvedValue(null);
+
+      await repository.findById(mockTypeRecord.id);
+
+      expect(mockDb.query.types.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.any(Function),
+        })
+      );
+    });
+  });
+
+  describe('findByName', () => {
+    it('should find type by exact name (lowercase)', async () => {
+      mockDb.query.types.findFirst.mockResolvedValue(mockTypeRecord);
+
+      const result = await repository.findByName('technical');
+
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('technical');
+    });
+
+    it('should find type by name case-insensitively', async () => {
+      mockDb.query.types.findFirst.mockResolvedValue(mockTypeRecord);
+
+      const result = await repository.findByName('TECHNICAL');
+
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('technical');
+    });
+
+    it('should find type by name with mixed case', async () => {
+      mockDb.query.types.findFirst.mockResolvedValue(mockTypeRecord);
+
+      const result = await repository.findByName('Technical');
+
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('technical');
+    });
+
+    it('should trim whitespace from name', async () => {
+      mockDb.query.types.findFirst.mockResolvedValue(mockTypeRecord);
+
+      await repository.findByName('  technical  ');
+
+      expect(mockDb.query.types.findFirst).toHaveBeenCalled();
+    });
+
+    it('should return null when type not found', async () => {
+      mockDb.query.types.findFirst.mockResolvedValue(null);
+
+      const result = await repository.findByName('nonexistent');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null for empty name', async () => {
+      const result = await repository.findByName('');
+
+      expect(result).toBeNull();
+      expect(mockDb.query.types.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('should return null for whitespace-only name', async () => {
+      const result = await repository.findByName('   ');
+
+      expect(result).toBeNull();
+      expect(mockDb.query.types.findFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all types', async () => {
+      mockDb.query.types.findMany.mockResolvedValue([
+        mockTypeRecord,
+        mockTypeRecord2,
+        mockTypeRecord3,
+      ]);
+
+      const result = await repository.findAll();
+
+      expect(result).toHaveLength(3);
+      expect(result[0].name).toBe('technical');
+      expect(result[1].name).toBe('novel');
+      expect(result[2].name).toBe('biography');
+    });
+
+    it('should return empty array when no types exist', async () => {
+      mockDb.query.types.findMany.mockResolvedValue([]);
+
+      const result = await repository.findAll();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return domain entities with all properties', async () => {
+      mockDb.query.types.findMany.mockResolvedValue([mockTypeRecord]);
+
+      const result = await repository.findAll();
+
+      expect(result[0].id).toBe(mockTypeRecord.id);
+      expect(result[0].name).toBe(mockTypeRecord.name);
+      expect(result[0].createdAt).toEqual(mockTypeRecord.createdAt);
+      expect(result[0].updatedAt).toEqual(mockTypeRecord.updatedAt);
+    });
+  });
+
+  describe('count', () => {
+    it('should return total count of types', async () => {
+      const mockSelect = vi.fn().mockReturnValue({
+        from: vi.fn().mockResolvedValue([{ count: '3' }]),
+      });
+      mockDb.select = mockSelect;
+
+      const result = await repository.count();
+
+      expect(result).toBe(3);
+    });
+
+    it('should return 0 when no types exist', async () => {
+      const mockSelect = vi.fn().mockReturnValue({
+        from: vi.fn().mockResolvedValue([{ count: '0' }]),
+      });
+      mockDb.select = mockSelect;
+
+      const result = await repository.count();
+
+      expect(result).toBe(0);
+    });
+
+    it('should handle null count result', async () => {
+      const mockSelect = vi.fn().mockReturnValue({
+        from: vi.fn().mockResolvedValue([{ count: null }]),
+      });
+      mockDb.select = mockSelect;
+
+      const result = await repository.count();
+
+      expect(result).toBe(0);
+    });
+  });
+
+  describe('TypeMapper integration', () => {
+    it('should correctly map database record to domain entity', async () => {
+      mockDb.query.types.findFirst.mockResolvedValue(mockTypeRecord);
+
+      const result = await repository.findById(mockTypeRecord.id);
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(mockTypeRecord.id);
+      expect(result!.name).toBe(mockTypeRecord.name);
+      expect(result!.createdAt).toEqual(mockTypeRecord.createdAt);
+      expect(result!.updatedAt).toEqual(mockTypeRecord.updatedAt);
+    });
+
+    it('should map multiple records correctly', async () => {
+      mockDb.query.types.findMany.mockResolvedValue([
+        mockTypeRecord,
+        mockTypeRecord2,
+      ]);
+
+      const result = await repository.findAll();
+
+      expect(result).toHaveLength(2);
+      result.forEach((type, index) => {
+        const expectedRecord = index === 0 ? mockTypeRecord : mockTypeRecord2;
+        expect(type.id).toBe(expectedRecord.id);
+        expect(type.name).toBe(expectedRecord.name);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement `TypeRepository` port interface for read-only access to book types
- Add `PostgresTypeRepository` adapter using Drizzle ORM with case-insensitive name lookup

## Changes

### New Files
- `src/application/ports/TypeRepository.ts` - Port interface defining:
  - `findById`, `findByName` (case-insensitive)
  - `findAll`, `count`
  - **Read-only** - no save/update methods (types are seeded data)

- `src/infrastructure/driven/persistence/PostgresTypeRepository.ts` - Adapter implementing:
  - Case-insensitive type lookup by normalizing names to lowercase
  - Uses existing `TypeMapper` for domain entity conversion

### Updated Files
- `src/application/ports/index.ts` - Export `TypeRepository`
- `src/infrastructure/driven/persistence/index.ts` - Export `PostgresTypeRepository`

### Tests
| Type | Count |
|------|-------|
| Unit | 18 |
| Integration | 19 |

**Total tests now passing:**
- Unit: 432 (+18)
- Integration: 88 (+19)

## Part of
TASK-008 for HU-002 (Initial Data Load)