### PR TITLE
feat(use-case): update CreateBookUseCase with TypeRepository and AuthorRepository

### DIFF
--- a/apps/api-cli/src/cli.ts
+++ b/apps/api-cli/src/cli.ts
@@ -18,6 +18,8 @@ import { CreateBookUseCase } from './application/use-cases/CreateBookUseCase.js'
 import { OllamaEmbeddingService } from './infrastructure/driven/embedding/OllamaEmbeddingService.js';
 import { PostgresBookRepository } from './infrastructure/driven/persistence/PostgresBookRepository.js';
 import { PostgresCategoryRepository } from './infrastructure/driven/persistence/PostgresCategoryRepository.js';
+import { PostgresTypeRepository } from './infrastructure/driven/persistence/PostgresTypeRepository.js';
+import { PostgresAuthorRepository } from './infrastructure/driven/persistence/PostgresAuthorRepository.js';
 import { createLogger } from './infrastructure/driven/logging/PinoLogger.js';
 import { createAddCommand } from './infrastructure/driver/cli/commands/add.js';
 import * as schema from './infrastructure/driven/persistence/drizzle/schema.js';
@@ -61,11 +63,15 @@ async function createCLI(): Promise<Command> {
 
   const bookRepository = new PostgresBookRepository(db);
   const categoryRepository = new PostgresCategoryRepository(db);
+  const typeRepository = new PostgresTypeRepository(db);
+  const authorRepository = new PostgresAuthorRepository(db);
 
   // Create use cases
   const createBookUseCase = new CreateBookUseCase({
     bookRepository,
     categoryRepository,
+    typeRepository,
+    authorRepository,
     embeddingService,
     logger,
   });

--- a/apps/api-cli/src/server.ts
+++ b/apps/api-cli/src/server.ts
@@ -12,6 +12,8 @@ import { PinoLogger } from './infrastructure/driven/logging/PinoLogger.js';
 import { OllamaEmbeddingService } from './infrastructure/driven/embedding/OllamaEmbeddingService.js';
 import { PostgresBookRepository } from './infrastructure/driven/persistence/PostgresBookRepository.js';
 import { PostgresCategoryRepository } from './infrastructure/driven/persistence/PostgresCategoryRepository.js';
+import { PostgresTypeRepository } from './infrastructure/driven/persistence/PostgresTypeRepository.js';
+import { PostgresAuthorRepository } from './infrastructure/driven/persistence/PostgresAuthorRepository.js';
 import { CreateBookUseCase } from './application/use-cases/CreateBookUseCase.js';
 import { createServer, startServer } from './infrastructure/driver/http/server.js';
 import * as schema from './infrastructure/driven/persistence/drizzle/schema.js';
@@ -45,11 +47,15 @@ async function bootstrap(): Promise<void> {
 
     const bookRepository = new PostgresBookRepository(db as any);
     const categoryRepository = new PostgresCategoryRepository(db as any);
+    const typeRepository = new PostgresTypeRepository(db as any);
+    const authorRepository = new PostgresAuthorRepository(db as any);
 
     // Initialize use cases
     const createBookUseCase = new CreateBookUseCase({
       bookRepository,
       categoryRepository,
+      typeRepository,
+      authorRepository,
       embeddingService,
       logger,
     });

--- a/apps/api-cli/tests/e2e/setup.ts
+++ b/apps/api-cli/tests/e2e/setup.ts
@@ -23,10 +23,12 @@ import { CreateBookUseCase } from '../../src/application/use-cases/CreateBookUse
 import { OllamaEmbeddingService } from '../../src/infrastructure/driven/embedding/OllamaEmbeddingService.js';
 import { PostgresBookRepository } from '../../src/infrastructure/driven/persistence/PostgresBookRepository.js';
 import { PostgresCategoryRepository } from '../../src/infrastructure/driven/persistence/PostgresCategoryRepository.js';
+import { PostgresTypeRepository } from '../../src/infrastructure/driven/persistence/PostgresTypeRepository.js';
+import { PostgresAuthorRepository } from '../../src/infrastructure/driven/persistence/PostgresAuthorRepository.js';
 import { noopLogger } from '../../src/application/ports/Logger.js';
 
 const { Pool } = pg;
-const { books, categories, bookCategories } = schema;
+const { books, categories, bookCategories, bookAuthors, authors } = schema;
 
 /**
  * Database instance type for E2E tests
@@ -78,9 +80,13 @@ export async function closeTestDb(db: TestDb): Promise<void> {
  * Clears all test data from tables
  */
 export async function clearTestData(db: TestDb): Promise<void> {
+  // Order matters due to FK constraints
   await db.delete(bookCategories);
+  await db.delete(bookAuthors);
   await db.delete(books);
   await db.delete(categories);
+  await db.delete(authors);
+  // Note: types table has seed data, don't delete it
 }
 
 /**
@@ -101,11 +107,17 @@ export async function createTestServer(db: TestDb): Promise<FastifyInstance> {
   const bookRepository = new PostgresBookRepository(db as any);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const categoryRepository = new PostgresCategoryRepository(db as any);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const typeRepository = new PostgresTypeRepository(db as any);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const authorRepository = new PostgresAuthorRepository(db as any);
 
   // Create use case
   const createBookUseCase = new CreateBookUseCase({
     bookRepository,
     categoryRepository,
+    typeRepository,
+    authorRepository,
     embeddingService,
     logger: noopLogger,
   });

--- a/apps/api-cli/tests/unit/application/use-cases/CreateBookUseCase.test.ts
+++ b/apps/api-cli/tests/unit/application/use-cases/CreateBookUseCase.test.ts
@@ -6,10 +6,14 @@ import {
 } from '../../../../src/application/use-cases/CreateBookUseCase.js';
 import type { BookRepository, DuplicateCheckResult } from '../../../../src/application/ports/BookRepository.js';
 import type { CategoryRepository } from '../../../../src/application/ports/CategoryRepository.js';
+import type { TypeRepository } from '../../../../src/application/ports/TypeRepository.js';
+import type { AuthorRepository } from '../../../../src/application/ports/AuthorRepository.js';
 import type { EmbeddingService, EmbeddingResult } from '../../../../src/application/ports/EmbeddingService.js';
 import { Category } from '../../../../src/domain/entities/Category.js';
+import { BookType } from '../../../../src/domain/entities/BookType.js';
+import { Author } from '../../../../src/domain/entities/Author.js';
 import { Book } from '../../../../src/domain/entities/Book.js';
-import { DuplicateISBNError } from '../../../../src/domain/errors/DomainErrors.js';
+import { DuplicateISBNError, InvalidBookTypeError } from '../../../../src/domain/errors/DomainErrors.js';
 import {
   EmbeddingTextTooLongError,
   EmbeddingServiceUnavailableError,
@@ -19,6 +23,8 @@ describe('CreateBookUseCase', () => {
   // Mock dependencies
   let mockBookRepository: BookRepository;
   let mockCategoryRepository: CategoryRepository;
+  let mockTypeRepository: TypeRepository;
+  let mockAuthorRepository: AuthorRepository;
   let mockEmbeddingService: EmbeddingService;
   let useCase: CreateBookUseCase;
 
@@ -39,6 +45,21 @@ describe('CreateBookUseCase', () => {
     Category.create({ id: '110e8400-e29b-41d4-a716-446655440001', name: 'programming' }),
     Category.create({ id: '220e8400-e29b-41d4-a716-446655440002', name: 'software engineering' }),
   ];
+
+  const mockTechnicalType = BookType.create({
+    id: '550e8400-e29b-41d4-a716-446655440010',
+    name: 'technical',
+  });
+
+  const mockNovelType = BookType.create({
+    id: '550e8400-e29b-41d4-a716-446655440011',
+    name: 'novel',
+  });
+
+  const mockAuthor = Author.create({
+    id: '550e8400-e29b-41d4-a716-446655440020',
+    name: 'Robert C. Martin',
+  });
 
   const mockEmbedding: number[] = new Array(768).fill(0.1);
 
@@ -75,6 +96,28 @@ describe('CreateBookUseCase', () => {
       findAll: vi.fn(),
     };
 
+    mockTypeRepository = {
+      findById: vi.fn(),
+      findByName: vi.fn().mockImplementation(async (name: string) => {
+        if (name === 'technical') return mockTechnicalType;
+        if (name === 'novel') return mockNovelType;
+        return null;
+      }),
+      findAll: vi.fn().mockResolvedValue([mockTechnicalType, mockNovelType]),
+      count: vi.fn().mockResolvedValue(2),
+    };
+
+    mockAuthorRepository = {
+      findById: vi.fn(),
+      findByName: vi.fn(),
+      findByNames: vi.fn(),
+      findOrCreate: vi.fn().mockResolvedValue(mockAuthor),
+      findOrCreateMany: vi.fn(),
+      save: vi.fn(),
+      findAll: vi.fn(),
+      count: vi.fn(),
+    };
+
     mockEmbeddingService = {
       generateEmbedding: vi.fn().mockResolvedValue(mockEmbeddingResult),
       isAvailable: vi.fn().mockResolvedValue(true),
@@ -83,6 +126,8 @@ describe('CreateBookUseCase', () => {
     const deps: CreateBookUseCaseDeps = {
       bookRepository: mockBookRepository,
       categoryRepository: mockCategoryRepository,
+      typeRepository: mockTypeRepository,
+      authorRepository: mockAuthorRepository,
       embeddingService: mockEmbeddingService,
     };
 
@@ -105,6 +150,24 @@ describe('CreateBookUseCase', () => {
       expect(result.id).toBeDefined();
       expect(result.createdAt).toBeDefined();
       expect(result.updatedAt).toBeDefined();
+    });
+
+    it('should validate type exists in database', async () => {
+      await useCase.execute(validInput);
+
+      expect(mockTypeRepository.findByName).toHaveBeenCalledWith('technical');
+    });
+
+    it('should throw InvalidBookTypeError for non-existent type', async () => {
+      const invalidInput = { ...validInput, type: 'nonexistent' };
+
+      await expect(useCase.execute(invalidInput)).rejects.toThrow(InvalidBookTypeError);
+    });
+
+    it('should resolve or create author', async () => {
+      await useCase.execute(validInput);
+
+      expect(mockAuthorRepository.findOrCreate).toHaveBeenCalledWith('Robert C. Martin');
     });
 
     it('should resolve or create categories', async () => {
@@ -190,12 +253,13 @@ describe('CreateBookUseCase', () => {
         title: 'Test Book',
         author: 'Test Author',
         description: 'Test Description',
-        type: { value: 'technical' },
+        type: { value: 'technical', name: 'technical' },
         format: { value: 'pdf' },
         isbn: null,
         available: false,
         path: null,
         categories: mockCategories,
+        authors: [mockAuthor],
         createdAt: new Date(),
         updatedAt: new Date(),
         getTextForEmbedding: () => longText, // This exceeds the limit
@@ -229,6 +293,12 @@ describe('CreateBookUseCase', () => {
         format: 'epub',
       };
 
+      const unknownAuthor = Author.create({
+        id: '550e8400-e29b-41d4-a716-446655440021',
+        name: 'Unknown Author',
+      });
+
+      (mockAuthorRepository.findOrCreate as ReturnType<typeof vi.fn>).mockResolvedValue(unknownAuthor);
       (mockCategoryRepository.findOrCreateMany as ReturnType<typeof vi.fn>).mockResolvedValue([
         Category.create({ id: '330e8400-e29b-41d4-a716-446655440003', name: 'fiction' }),
       ]);


### PR DESCRIPTION
## Summary

TASK-010: Update CreateBookUseCase to use repository-based type and author resolution instead of in-memory entity creation.

## Changes

### CreateBookUseCase Updates
- Use `TypeRepository.findByName()` to validate book type exists in database
- Use `AuthorRepository.findOrCreate()` instead of creating Author entity in-memory
- Throw `InvalidBookTypeError` when type doesn't exist in DB

### Dependency Injection
- Updated `cli.ts` to inject `PostgresTypeRepository` and `PostgresAuthorRepository`
- Updated `server.ts` to inject `PostgresTypeRepository` and `PostgresAuthorRepository`

### Test Updates
- **Unit tests**: Added mocks for TypeRepository and AuthorRepository, added test for InvalidBookTypeError
- **Integration tests**: Enabled and updated with new dependencies
- **E2E tests**: Enabled HTTP and CLI tests, updated setup.ts with new repositories
- Removed triad duplicate detection tests (no longer applicable with multi-author model)
- Changed test fixture type 'essay' to 'biography' (essay doesn't exist in seeded types)

## Test Results
- ✅ 435 unit tests pass
- ✅ 103 integration tests pass  
- ✅ 30 E2E tests pass (+ 2 skipped for 503 scenarios)