### PR TITLE
refactor: remove code duplication in controllers and repositories

### DIFF
--- a/apps/api-cli/src/infrastructure/driven/persistence/PostgresLevelRepository.ts
+++ b/apps/api-cli/src/infrastructure/driven/persistence/PostgresLevelRepository.ts
@@ -149,8 +149,7 @@ export class PostgresLevelRepository implements LevelRepository {
       })
       .from(levels)
       .innerJoin(typeLevels, eq(levels.id, typeLevels.levelId))
-      .where(eq(typeLevels.typeId, typeId))
-      .orderBy(asc(levels.name));
+      .where(eq(typeLevels.typeId, typeId));
 
     return LevelMapper.toDomainList(results);
   }

--- a/apps/api-cli/src/infrastructure/driver/http/controllers/BookLevelsController.ts
+++ b/apps/api-cli/src/infrastructure/driver/http/controllers/BookLevelsController.ts
@@ -14,7 +14,6 @@ import { noopLogger } from '../../../../application/ports/Logger.js';
 import { successResponse } from '../schemas/common.schemas.js';
 import { mapErrorToHttpResponse } from '../errors/HttpErrorMapper.js';
 import { listBookLevelsQuerySchema } from '../schemas/book-level.schemas.js';
-import { ZodError } from 'zod';
 
 /**
  * Dependencies required by BookLevelsController
@@ -81,23 +80,6 @@ export class BookLevelsController {
 
       return reply.status(200).send(successResponse(levels));
     } catch (error) {
-      // Handle Zod validation errors
-      if (error instanceof ZodError) {
-        const details = error.errors.map(
-          (e) => `${e.path.join('.')}: ${e.message}`,
-        );
-        this.logger.debug('Validation error', { details });
-
-        return reply.status(400).send({
-          success: false,
-          data: null,
-          error: {
-            message: 'Validation failed',
-            details,
-          },
-        });
-      }
-
       const errorResponse = mapErrorToHttpResponse(error);
 
       if (errorResponse.statusCode >= 500) {

--- a/apps/api-cli/src/infrastructure/driver/http/controllers/CategoriesController.ts
+++ b/apps/api-cli/src/infrastructure/driver/http/controllers/CategoriesController.ts
@@ -14,7 +14,6 @@ import { noopLogger } from '../../../../application/ports/Logger.js';
 import { successResponse } from '../schemas/common.schemas.js';
 import { mapErrorToHttpResponse } from '../errors/HttpErrorMapper.js';
 import { listCategoriesQuerySchema } from '../schemas/category.schemas.js';
-import { ZodError } from 'zod';
 
 /**
  * Dependencies required by CategoriesController
@@ -81,23 +80,6 @@ export class CategoriesController {
 
       return reply.status(200).send(successResponse(categories));
     } catch (error) {
-      // Handle Zod validation errors
-      if (error instanceof ZodError) {
-        const details = error.errors.map(
-          (e) => `${e.path.join('.')}: ${e.message}`,
-        );
-        this.logger.debug('Validation error', { details });
-
-        return reply.status(400).send({
-          success: false,
-          data: null,
-          error: {
-            message: 'Validation failed',
-            details,
-          },
-        });
-      }
-
       const errorResponse = mapErrorToHttpResponse(error);
 
       if (errorResponse.statusCode >= 500) {

--- a/apps/api-cli/tests/unit/infrastructure/driven/persistence/PostgresLevelRepository.test.ts
+++ b/apps/api-cli/tests/unit/infrastructure/driven/persistence/PostgresLevelRepository.test.ts
@@ -348,9 +348,7 @@ describe('PostgresLevelRepository', () => {
       const mockSelect = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
           innerJoin: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              orderBy: vi.fn().mockResolvedValue([mockLevelRecord, mockLevelRecord2]),
-            }),
+            where: vi.fn().mockResolvedValue([mockLevelRecord, mockLevelRecord2]),
           }),
         }),
       });
@@ -367,9 +365,7 @@ describe('PostgresLevelRepository', () => {
       const mockSelect = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
           innerJoin: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              orderBy: vi.fn().mockResolvedValue([]),
-            }),
+            where: vi.fn().mockResolvedValue([]),
           }),
         }),
       });
@@ -381,8 +377,7 @@ describe('PostgresLevelRepository', () => {
     });
 
     it('should call select with join on typeLevels', async () => {
-      const mockOrderBy = vi.fn().mockResolvedValue([]);
-      const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+      const mockWhere = vi.fn().mockResolvedValue([]);
       const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
       const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
       const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });


### PR DESCRIPTION
## Summary

Code review improvements for HU-010 implementation:

- **Remove duplicate ZodError handling** in `BookLevelsController` and `CategoriesController` - the centralized `mapErrorToHttpResponse` already handles `ZodError`, so the manual handling was redundant
- **Fix `findByTypeId` in `PostgresLevelRepository`** - it was incorrectly ordering results (duplicating `findByTypeIdSorted` behavior). Now consistent with `CategoryRepository` pattern where `findByTypeId` returns unordered and `findByTypeIdSorted` returns ordered

## Changes

| File | Change |
|------|--------|
| `BookLevelsController.ts` | Remove duplicate ZodError handling block, remove unused `ZodError` import |
| `CategoriesController.ts` | Remove duplicate ZodError handling block, remove unused `ZodError` import |
| `PostgresLevelRepository.ts` | Remove `orderBy` from `findByTypeId` to differentiate from `findByTypeIdSorted` |
| `PostgresLevelRepository.test.ts` | Update mocks to not expect `orderBy` in `findByTypeId` |

## Benefits

1. **DRY principle** - Error handling is centralized in `HttpErrorMapper`
2. **Consistency** - `findByTypeId` now behaves the same across all repositories
3. **Clarity** - Clear separation between sorted and unsorted query methods

## Test Results
- ✅ 891 unit tests passing
- ✅ 34 E2E tests passing (book-levels + categories)