### PR TITLE
refactor(HU-012): fix N+1 query, cursor pagination bug, and add criteria utilities

### DIFF
--- a/apps/api-cli/src/domain/criteria/Criteria.ts
+++ b/apps/api-cli/src/domain/criteria/Criteria.ts
@@ -13,16 +13,8 @@
 import { Filters } from './Filters.js';
 import { Filter } from './Filter.js';
 import { Order } from './Order.js';
+import { PAGINATION } from './constants.js';
 import type { FilterValueType } from './FilterValue.js';
-
-/**
- * Pagination constraints
- */
-const PAGINATION_CONSTRAINTS = {
-  DEFAULT_LIMIT: 50,
-  MIN_LIMIT: 1,
-  MAX_LIMIT: 100,
-} as const;
 
 /**
  * Props for creating a Criteria
@@ -59,7 +51,7 @@ export class Criteria {
    */
   static create(props: CriteriaProps = {}): Criteria {
     const limit = Criteria.validateLimit(
-      props.limit ?? PAGINATION_CONSTRAINTS.DEFAULT_LIMIT,
+      props.limit ?? PAGINATION.DEFAULT_LIMIT,
     );
 
     return new Criteria({
@@ -255,11 +247,11 @@ export class Criteria {
    * Validates and constrains the limit value
    */
   private static validateLimit(limit: number): number {
-    if (limit < PAGINATION_CONSTRAINTS.MIN_LIMIT) {
-      return PAGINATION_CONSTRAINTS.MIN_LIMIT;
+    if (limit < PAGINATION.MIN_LIMIT) {
+      return PAGINATION.MIN_LIMIT;
     }
-    if (limit > PAGINATION_CONSTRAINTS.MAX_LIMIT) {
-      return PAGINATION_CONSTRAINTS.MAX_LIMIT;
+    if (limit > PAGINATION.MAX_LIMIT) {
+      return PAGINATION.MAX_LIMIT;
     }
     return Math.floor(limit);
   }
@@ -268,14 +260,14 @@ export class Criteria {
    * Returns the default limit value
    */
   static getDefaultLimit(): number {
-    return PAGINATION_CONSTRAINTS.DEFAULT_LIMIT;
+    return PAGINATION.DEFAULT_LIMIT;
   }
 
   /**
    * Returns the maximum allowed limit
    */
   static getMaxLimit(): number {
-    return PAGINATION_CONSTRAINTS.MAX_LIMIT;
+    return PAGINATION.MAX_LIMIT;
   }
 
   equals(other: Criteria): boolean {

--- a/apps/api-cli/src/domain/criteria/Filter.ts
+++ b/apps/api-cli/src/domain/criteria/Filter.ts
@@ -89,6 +89,20 @@ export class Filter {
   }
 
   /**
+   * Creates a greater than or equal filter
+   */
+  static greaterThanOrEqual(field: string, value: number): Filter {
+    return Filter.create(field, 'GTE', value);
+  }
+
+  /**
+   * Creates a less than or equal filter
+   */
+  static lessThanOrEqual(field: string, value: number): Filter {
+    return Filter.create(field, 'LTE', value);
+  }
+
+  /**
    * Checks if this filter uses the SIMILAR_TO operator
    */
   isSimilarityFilter(): boolean {

--- a/apps/api-cli/src/domain/criteria/Filters.ts
+++ b/apps/api-cli/src/domain/criteria/Filters.ts
@@ -126,6 +126,13 @@ export class Filters {
     return this.items.map(callback);
   }
 
+  /**
+   * Filters the collection based on a predicate and returns a new Filters instance
+   */
+  filter(predicate: (filter: Filter, index: number) => boolean): Filters {
+    return new Filters(this.items.filter(predicate));
+  }
+
   equals(other: Filters): boolean {
     if (this.items.length !== other.items.length) {
       return false;

--- a/apps/api-cli/src/domain/criteria/constants.ts
+++ b/apps/api-cli/src/domain/criteria/constants.ts
@@ -1,0 +1,31 @@
+/**
+ * Search and Pagination Constants
+ *
+ * Domain constants for search criteria configuration.
+ * These values define the constraints and defaults for
+ * pagination and semantic search operations.
+ */
+
+/**
+ * Pagination constraints for search operations
+ */
+export const PAGINATION = {
+  /** Default number of results per page */
+  DEFAULT_LIMIT: 50,
+  /** Minimum allowed limit */
+  MIN_LIMIT: 1,
+  /** Maximum allowed limit */
+  MAX_LIMIT: 100,
+} as const;
+
+/**
+ * Semantic search configuration
+ */
+export const SEMANTIC_SEARCH = {
+  /**
+   * Minimum similarity threshold for semantic search results.
+   * Results with similarity score below this value are filtered out.
+   * Value range: 0.0 to 1.0 (0% to 100%)
+   */
+  SIMILARITY_THRESHOLD: 0.7,
+} as const;

--- a/apps/api-cli/src/domain/criteria/index.ts
+++ b/apps/api-cli/src/domain/criteria/index.ts
@@ -6,6 +6,9 @@
  * ordering, and paginating data without coupling to infrastructure details.
  */
 
+// Constants
+export { PAGINATION, SEMANTIC_SEARCH } from './constants.js';
+
 // Main Criteria class
 export { Criteria, type CriteriaProps } from './Criteria.js';
 

--- a/apps/api-cli/src/infrastructure/driven/persistence/PostgresBookRepository.ts
+++ b/apps/api-cli/src/infrastructure/driven/persistence/PostgresBookRepository.ts
@@ -29,6 +29,7 @@ import type { BookType } from '../../../domain/entities/BookType.js';
 import type { Category } from '../../../domain/entities/Category.js';
 import type { Criteria } from '../../../domain/criteria/Criteria.js';
 import type { Filter } from '../../../domain/criteria/Filter.js';
+import { SEMANTIC_SEARCH } from '../../../domain/criteria/constants.js';
 import { DuplicateISBNError, BookNotFoundError } from '../../../domain/errors/DomainErrors.js';
 import type {
   BookRepository,
@@ -381,10 +382,13 @@ export class PostgresBookRepository implements BookRepository {
    */
   async search(criteria: Criteria, embedding?: number[]): Promise<SearchBooksResult> {
     const hasEmbedding = embedding !== undefined && embedding.length > 0;
-    const SIMILARITY_THRESHOLD = 0.7;
 
     // Build where conditions from criteria filters
-    const whereConditions = this.buildWhereConditions(criteria, embedding, SIMILARITY_THRESHOLD);
+    const whereConditions = this.buildWhereConditions(
+      criteria,
+      embedding,
+      SEMANTIC_SEARCH.SIMILARITY_THRESHOLD,
+    );
 
     // Build the order by clause
     const orderByClause = this.buildOrderByClause(criteria, hasEmbedding);
@@ -628,9 +632,9 @@ export class PostgresBookRepository implements BookRepository {
     embedding: number[] | undefined,
     hasEmbedding: boolean,
   ): Promise<SearchResultRow[]> {
-    // Build cursor condition
+    // Build cursor condition (pass embedding for similarity pagination)
     const cursorCondition = cursor
-      ? this.buildCursorCondition(cursor, orderBy, hasEmbedding)
+      ? this.buildCursorCondition(cursor, orderBy, hasEmbedding, embedding)
       : undefined;
 
     // Combine where conditions with cursor
@@ -674,18 +678,24 @@ export class PostgresBookRepository implements BookRepository {
 
   /**
    * Builds cursor condition for pagination
+   *
+   * For similarity-based pagination, we compare the current book's similarity score
+   * (calculated using the original query embedding) against the last seen score.
    */
   private buildCursorCondition(
     cursor: CursorData,
     orderBy: 'similarity_desc' | 'title_asc' | 'title_desc' | 'custom_asc' | 'custom_desc',
     hasEmbedding: boolean,
+    embedding?: number[],
   ): ReturnType<typeof sql> {
-    if (hasEmbedding && cursor.lastScore !== undefined) {
-      // For similarity ordering: (score, id) < (lastScore, lastId)
+    if (hasEmbedding && cursor.lastScore !== undefined && embedding) {
+      // For similarity ordering (DESC): get books with lower similarity scores,
+      // or same score but higher ID (for tie-breaking)
+      const embeddingStr = `[${embedding.join(',')}]`;
       return sql`(
-        1 - (${books.embedding} <=> '[${sql.raw(cursor.lastScore.toString())}]'::vector) < ${cursor.lastScore}
+        1 - (${books.embedding} <=> ${embeddingStr}::vector) < ${cursor.lastScore}
         OR (
-          1 - (${books.embedding} <=> '[${sql.raw(cursor.lastScore.toString())}]'::vector) = ${cursor.lastScore}
+          1 - (${books.embedding} <=> ${embeddingStr}::vector) = ${cursor.lastScore}
           AND ${books.id} > ${cursor.lastId}
         )
       )`;
@@ -734,19 +744,37 @@ export class PostgresBookRepository implements BookRepository {
 
   /**
    * Maps search result rows to BookWithScore objects
+   *
+   * Uses batch loading to avoid N+1 query problem:
+   * - 1 query for all authors (instead of N)
+   * - 1 query for all types (instead of N)
+   * - 1 query for all categories (instead of N)
+   * - 1 query for type-level relationships
    */
   private async mapResultsToBooksWithScores(
     results: SearchResultRow[],
     hasEmbedding: boolean,
   ): Promise<BookWithScore[]> {
-    const booksWithScores: BookWithScore[] = [];
+    if (results.length === 0) {
+      return [];
+    }
 
-    for (const row of results) {
-      const [bookAuthors, bookType, bookCategories] = await Promise.all([
-        this.fetchAuthorsForBook(row.id),
-        this.fetchTypeForBook(row.typeId),
-        this.fetchCategoriesForBook(row.id),
-      ]);
+    // Extract unique IDs for batch loading
+    const bookIds = results.map((r) => r.id);
+    const typeIds = [...new Set(results.map((r) => r.typeId))];
+
+    // Batch load all relations in parallel (3 queries instead of N*3)
+    const [authorsMap, typesMap, categoriesMap] = await Promise.all([
+      this.fetchAuthorsForBooks(bookIds),
+      this.fetchTypesWithLevels(typeIds),
+      this.fetchCategoriesForBooks(bookIds),
+    ]);
+
+    // Map results to BookWithScore
+    return results.map((row) => {
+      const bookAuthors = authorsMap.get(row.id) ?? [];
+      const bookType = typesMap.get(row.typeId);
+      const bookCategories = categoriesMap.get(row.id) ?? [];
 
       if (!bookType) {
         throw new Error(`Book type not found for type_id: ${row.typeId}`);
@@ -771,14 +799,117 @@ export class PostgresBookRepository implements BookRepository {
 
       const book = BookMapper.toDomain(bookRecord, bookAuthors, bookType, bookCategories);
 
-      booksWithScores.push({
+      return {
         book,
         similarityScore: hasEmbedding ? row.similarity_score : null,
         levelName: row.levelName,
-      });
+      };
+    });
+  }
+
+  // ==================== Batch Loading Methods ====================
+
+  /**
+   * Batch loads authors for multiple books in a single query
+   * Returns a Map of bookId -> Author[]
+   */
+  private async fetchAuthorsForBooks(bookIds: string[]): Promise<Map<string, Author[]>> {
+    if (bookIds.length === 0) {
+      return new Map();
     }
 
-    return booksWithScores;
+    const results = await this.db
+      .select({
+        bookId: bookAuthors.bookId,
+        author: authors,
+      })
+      .from(bookAuthors)
+      .innerJoin(authors, eq(bookAuthors.authorId, authors.id))
+      .where(sql`${bookAuthors.bookId} IN (${sql.join(bookIds.map(id => sql`${id}`), sql`, `)})`);
+
+    // Group by bookId
+    const authorsMap = new Map<string, Author[]>();
+    for (const row of results) {
+      const author = AuthorMapper.toDomain(row.author);
+      const existing = authorsMap.get(row.bookId) ?? [];
+      existing.push(author);
+      authorsMap.set(row.bookId, existing);
+    }
+
+    return authorsMap;
+  }
+
+  /**
+   * Batch loads types with their levelIds for multiple type IDs
+   * Returns a Map of typeId -> BookType
+   */
+  private async fetchTypesWithLevels(typeIds: string[]): Promise<Map<string, BookType>> {
+    if (typeIds.length === 0) {
+      return new Map();
+    }
+
+    // Load types
+    const typeResults = await this.db
+      .select()
+      .from(types)
+      .where(sql`${types.id} IN (${sql.join(typeIds.map(id => sql`${id}`), sql`, `)})`);
+
+    // Load type-level relationships for all types
+    const typeLevelResults = await this.db
+      .select({
+        typeId: typeLevels.typeId,
+        levelId: typeLevels.levelId,
+      })
+      .from(typeLevels)
+      .where(sql`${typeLevels.typeId} IN (${sql.join(typeIds.map(id => sql`${id}`), sql`, `)})`);
+
+    // Group levelIds by typeId
+    const levelIdsByType = new Map<string, string[]>();
+    for (const row of typeLevelResults) {
+      const existing = levelIdsByType.get(row.typeId) ?? [];
+      existing.push(row.levelId);
+      levelIdsByType.set(row.typeId, existing);
+    }
+
+    // Build type map
+    const typesMap = new Map<string, BookType>();
+    for (const typeRecord of typeResults) {
+      const levelIds = levelIdsByType.get(typeRecord.id) ?? [];
+      const recordWithLevels = this.combineTypeWithLevelIds(typeRecord, levelIds);
+      typesMap.set(typeRecord.id, TypeMapper.toDomain(recordWithLevels));
+    }
+
+    return typesMap;
+  }
+
+  /**
+   * Batch loads categories for multiple books in a single query
+   * Returns a Map of bookId -> Category[]
+   */
+  private async fetchCategoriesForBooks(bookIds: string[]): Promise<Map<string, Category[]>> {
+    if (bookIds.length === 0) {
+      return new Map();
+    }
+
+    const results = await this.db
+      .select({
+        bookId: bookCategories.bookId,
+        category: categories,
+      })
+      .from(bookCategories)
+      .innerJoin(categories, eq(bookCategories.categoryId, categories.id))
+      .where(sql`${bookCategories.bookId} IN (${sql.join(bookIds.map(id => sql`${id}`), sql`, `)})`);
+
+    // Group by bookId
+    const categoriesMap = new Map<string, Category[]>();
+    for (const row of results) {
+      const category = CategoryMapper.toDomain(row.category);
+      const existing = categoriesMap.get(row.bookId) ?? [];
+      existing.push(category);
+      categoriesMap.set(row.bookId, existing);
+    }
+
+    return categoriesMap;
   }
 
   // ==================== Private Helpers ====================

--- a/apps/api-cli/tests/unit/domain/criteria/Filter.test.ts
+++ b/apps/api-cli/tests/unit/domain/criteria/Filter.test.ts
@@ -91,6 +91,26 @@ describe('Filter', () => {
         expect(filter.value.value).toBe(50);
       });
     });
+
+    describe('greaterThanOrEqual', () => {
+      it('should create a GTE filter', () => {
+        const filter = Filter.greaterThanOrEqual('year', 2020);
+
+        expect(filter.field.value).toBe('year');
+        expect(filter.operator.equals(FilterOperator.GTE)).toBe(true);
+        expect(filter.value.value).toBe(2020);
+      });
+    });
+
+    describe('lessThanOrEqual', () => {
+      it('should create a LTE filter', () => {
+        const filter = Filter.lessThanOrEqual('price', 100);
+
+        expect(filter.field.value).toBe('price');
+        expect(filter.operator.equals(FilterOperator.LTE)).toBe(true);
+        expect(filter.value.value).toBe(100);
+      });
+    });
   });
 
   describe('isSimilarityFilter', () => {

--- a/apps/api-cli/tests/unit/domain/criteria/Filters.test.ts
+++ b/apps/api-cli/tests/unit/domain/criteria/Filters.test.ts
@@ -190,6 +190,47 @@ describe('Filters', () => {
     });
   });
 
+  describe('filter', () => {
+    it('should filter based on predicate and return new Filters instance', () => {
+      const filters = Filters.fromValues([
+        Filter.equals('title', 'test'),
+        Filter.contains('author', 'martin'),
+        Filter.equals('year', '2020'),
+      ]);
+
+      const equalsFilters = filters.filter(
+        f => f.operator.value === 'EQUALS',
+      );
+
+      expect(equalsFilters.count()).toBe(2);
+      expect(equalsFilters.hasField('title')).toBe(true);
+      expect(equalsFilters.hasField('year')).toBe(true);
+      expect(equalsFilters.hasField('author')).toBe(false);
+    });
+
+    it('should return empty filters when no matches', () => {
+      const filters = Filters.fromValues([
+        Filter.equals('title', 'test'),
+        Filter.contains('author', 'martin'),
+      ]);
+
+      const noMatches = filters.filter(f => f.field.value === 'nonexistent');
+
+      expect(noMatches.isEmpty()).toBe(true);
+    });
+
+    it('should not modify original filters', () => {
+      const original = Filters.fromValues([
+        Filter.equals('title', 'test'),
+        Filter.contains('author', 'martin'),
+      ]);
+
+      original.filter(f => f.field.value === 'title');
+
+      expect(original.count()).toBe(2);
+    });
+  });
+
   describe('equals', () => {
     it('should return true for identical filters collections', () => {
       const filters1 = Filters.fromValues([


### PR DESCRIPTION
## Summary

- **Fix critical N+1 query problem** in `PostgresBookRepository`: reduces 150+ queries to 3-4 for 50 books by implementing batch loading (`fetchAuthorsForBooks`, `fetchTypesWithLevels`, `fetchCategoriesForBooks`)
- **Fix cursor pagination bug** in `buildCursorCondition`: now correctly uses the original query embedding for similarity calculation instead of invalid SQL

## Additional Improvements

- Extract constants to `domain/criteria/constants.ts` (`PAGINATION`, `SEMANTIC_SEARCH`)
- Add `Filter.greaterThanOrEqual()` and `Filter.lessThanOrEqual()` convenience methods
- Add `Filters.filter()` method for functional filtering
- Add unit tests for all new methods

## Test Results

- ✅ Unit: 1213 passed
- ✅ Integration: 164 passed
- ✅ E2E: 88 passed, 1 skipped