### PR TITLE
Task #287: Migrate book-table component to native table + Tailwind

### DIFF
--- a/apps/web-client/src/app/catalog/components/table/book-table/book-table.component.spec.ts
+++ b/apps/web-client/src/app/catalog/components/table/book-table/book-table.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { BookTableComponent } from './book-table.component';
 import { Book } from '../../../../core/models/index';
 
@@ -48,7 +47,7 @@ describe('BookTableComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [BookTableComponent, NoopAnimationsModule],
+      imports: [BookTableComponent],
     }).compileComponents();
 
     fixture = TestBed.createComponent(BookTableComponent);
@@ -79,7 +78,7 @@ describe('BookTableComponent', () => {
       fixture.componentRef.setInput('books', mockBooks);
       fixture.detectChanges();
 
-      const headerRow = fixture.nativeElement.querySelector('tr.mat-mdc-header-row');
+      const headerRow = fixture.nativeElement.querySelector('thead tr');
       expect(headerRow).toBeTruthy();
     });
 
@@ -87,33 +86,25 @@ describe('BookTableComponent', () => {
       fixture.componentRef.setInput('books', mockBooks);
       fixture.detectChanges();
 
-      const rows = fixture.nativeElement.querySelectorAll('tr.mat-mdc-row');
+      const rows = fixture.nativeElement.querySelectorAll('tbody tr.book-row');
       expect(rows.length).toBe(2);
     });
   });
 
   describe('Column display', () => {
-    it('should display title column', () => {
+    it('should display all header columns', () => {
       fixture.componentRef.setInput('books', mockBooks);
       fixture.detectChanges();
 
-      const titleHeader = fixture.nativeElement.querySelector('th.mat-column-title');
-      expect(titleHeader).toBeTruthy();
-    });
-
-    it('should display authors column', () => {
-      fixture.componentRef.setInput('books', mockBooks);
-      fixture.detectChanges();
-
-      const authorsHeader = fixture.nativeElement.querySelector('th.mat-column-authors');
-      expect(authorsHeader).toBeTruthy();
+      const headers = fixture.nativeElement.querySelectorAll('th');
+      expect(headers.length).toBe(8); // ISBN, Book Details, Type/Category, Lang, Level, Format, Description, Actions
     });
 
     it('should display book title in cell', () => {
       fixture.componentRef.setInput('books', mockBooks);
       fixture.detectChanges();
 
-      const titleCell = fixture.nativeElement.querySelector('td.mat-column-title');
+      const titleCell = fixture.nativeElement.querySelector('.book-title');
       expect(titleCell.textContent).toContain('Clean Code');
     });
 
@@ -121,8 +112,26 @@ describe('BookTableComponent', () => {
       fixture.componentRef.setInput('books', mockBooks);
       fixture.detectChanges();
 
-      const authorsCells = fixture.nativeElement.querySelectorAll('td.mat-column-authors');
-      expect(authorsCells[1].textContent).toContain('David Thomas');
+      const authorCells = fixture.nativeElement.querySelectorAll('.book-author');
+      expect(authorCells[0].textContent).toContain('Robert C. Martin');
+      expect(authorCells[1].textContent).toContain('David Thomas, Andrew Hunt');
+    });
+
+    it('should display ISBN in cell', () => {
+      fixture.componentRef.setInput('books', mockBooks);
+      fixture.detectChanges();
+
+      const isbnCell = fixture.nativeElement.querySelector('.isbn-text');
+      expect(isbnCell.textContent).toContain('978-0132350884');
+    });
+
+    it('should display format in cell', () => {
+      fixture.componentRef.setInput('books', mockBooks);
+      fixture.detectChanges();
+
+      const formatCells = fixture.nativeElement.querySelectorAll('.format-text');
+      expect(formatCells[0].textContent).toBe('pdf');
+      expect(formatCells[1].textContent).toBe('epub');
     });
   });
 
@@ -133,14 +142,6 @@ describe('BookTableComponent', () => {
 
       const levelBadges = fixture.nativeElement.querySelectorAll('app-level-badge');
       expect(levelBadges.length).toBe(2);
-    });
-
-    it('should render format icon for each book', () => {
-      fixture.componentRef.setInput('books', mockBooks);
-      fixture.detectChanges();
-
-      const formatIcons = fixture.nativeElement.querySelectorAll('app-format-icon');
-      expect(formatIcons.length).toBe(2);
     });
 
     it('should render language flag for each book', () => {
@@ -158,6 +159,14 @@ describe('BookTableComponent', () => {
       const categoryChips = fixture.nativeElement.querySelectorAll('app-category-chips');
       expect(categoryChips.length).toBe(2);
     });
+
+    it('should render truncated text for descriptions', () => {
+      fixture.componentRef.setInput('books', mockBooks);
+      fixture.detectChanges();
+
+      const truncatedTexts = fixture.nativeElement.querySelectorAll('app-truncated-text');
+      expect(truncatedTexts.length).toBe(2);
+    });
   });
 
   describe('Actions', () => {
@@ -167,6 +176,15 @@ describe('BookTableComponent', () => {
 
       const kindleButtons = fixture.nativeElement.querySelectorAll('[aria-label="Send to Kindle"]');
       expect(kindleButtons.length).toBe(2);
+    });
+
+    it('should render Material Symbols icon in action button', () => {
+      fixture.componentRef.setInput('books', mockBooks);
+      fixture.detectChanges();
+
+      const icon = fixture.nativeElement.querySelector('.action-button .material-symbols-outlined');
+      expect(icon).toBeTruthy();
+      expect(icon.textContent.trim()).toBe('send_to_mobile');
     });
 
     it('should emit sendToKindle event when kindle button is clicked', () => {
@@ -189,10 +207,27 @@ describe('BookTableComponent', () => {
       fixture.componentRef.setInput('books', mockBooks);
       fixture.detectChanges();
 
-      const row = fixture.nativeElement.querySelector('tr.mat-mdc-row');
+      const row = fixture.nativeElement.querySelector('tbody tr.book-row');
       row.click();
 
       expect(rowClickSpy).toHaveBeenCalledWith(mockBooks[0]);
+    });
+
+    it('should stop propagation when action button is clicked', () => {
+      const kindleSpy = vi.fn();
+      const rowClickSpy = vi.fn();
+      component.sendToKindle.subscribe(kindleSpy);
+      component.rowClick.subscribe(rowClickSpy);
+
+      fixture.componentRef.setInput('books', mockBooks);
+      fixture.detectChanges();
+
+      const kindleButton = fixture.nativeElement.querySelector('[aria-label="Send to Kindle"]');
+      kindleButton.click();
+
+      // Should only emit sendToKindle, not rowClick
+      expect(kindleSpy).toHaveBeenCalledWith(mockBooks[0]);
+      expect(rowClickSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -234,12 +269,26 @@ describe('BookTableComponent', () => {
       expect(table.getAttribute('aria-label')).toBe('Books');
     });
 
-    it('should have clickable rows with proper role', () => {
+    it('should have clickable rows with proper tabindex', () => {
       fixture.componentRef.setInput('books', mockBooks);
       fixture.detectChanges();
 
-      const row = fixture.nativeElement.querySelector('tr.mat-mdc-row');
+      const row = fixture.nativeElement.querySelector('tbody tr.book-row');
       expect(row.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('should have keyboard navigation support on rows', () => {
+      const rowClickSpy = vi.fn();
+      component.rowClick.subscribe(rowClickSpy);
+
+      fixture.componentRef.setInput('books', mockBooks);
+      fixture.detectChanges();
+
+      const row = fixture.nativeElement.querySelector('tbody tr.book-row');
+      const enterEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+      row.dispatchEvent(enterEvent);
+
+      expect(rowClickSpy).toHaveBeenCalledWith(mockBooks[0]);
     });
   });
 });

--- a/apps/web-client/src/app/catalog/components/table/book-table/book-table.component.ts
+++ b/apps/web-client/src/app/catalog/components/table/book-table/book-table.component.ts
@@ -1,7 +1,4 @@
 import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
-import { MatTableModule } from '@angular/material/table';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
 import { CategoryChipsComponent } from '../../data-display/category-chips/category-chips.component.js';
 import { LevelBadgeComponent } from '../../data-display/level-badge/level-badge.component.js';
 import { LanguageFlagComponent } from '../../data-display/language-flag/language-flag.component.js';
@@ -14,9 +11,6 @@ import { Book } from '../../../../core/models/index.js';
   selector: 'app-book-table',
   standalone: true,
   imports: [
-    MatTableModule,
-    MatButtonModule,
-    MatIconModule,
     CategoryChipsComponent,
     LevelBadgeComponent,
     LanguageFlagComponent,
@@ -31,101 +25,76 @@ import { Book } from '../../../../core/models/index.js';
       @if (books().length > 0) {
         <div class="book-table-container">
           <div class="table-scroll">
-            <table mat-table [dataSource]="books()" aria-label="Books" class="book-table">
-              <!-- ISBN Column -->
-              <ng-container matColumnDef="isbn">
-                <th mat-header-cell *matHeaderCellDef>ISBN</th>
-                <td mat-cell *matCellDef="let book">
-                  <span class="isbn-text">{{ book.isbn || '-' }}</span>
-                </td>
-              </ng-container>
-
-              <!-- Title Column -->
-              <ng-container matColumnDef="title">
-                <th mat-header-cell *matHeaderCellDef>Book Details</th>
-                <td mat-cell *matCellDef="let book">
-                  <div class="title-cell">
-                    <span class="book-title">{{ book.title }}</span>
-                    <span class="book-author">{{ getAuthorNames(book) }}</span>
-                  </div>
-                </td>
-              </ng-container>
-
-              <!-- Type/Category Column -->
-              <ng-container matColumnDef="typeCategory">
-                <th mat-header-cell *matHeaderCellDef>Type / Category</th>
-                <td mat-cell *matCellDef="let book">
-                  <div class="type-category-cell">
-                    <span class="book-type">{{ book.type?.name || 'Unknown' }}</span>
-                    <app-category-chips [categories]="getCategoryNames(book)" [maxVisible]="1" />
-                  </div>
-                </td>
-              </ng-container>
-
-              <!-- Language Column -->
-              <ng-container matColumnDef="language">
-                <th mat-header-cell *matHeaderCellDef class="text-center">Lang</th>
-                <td mat-cell *matCellDef="let book" class="text-center">
-                  <app-language-flag [languageCode]="book.language" />
-                </td>
-              </ng-container>
-
-              <!-- Level Column -->
-              <ng-container matColumnDef="level">
-                <th mat-header-cell *matHeaderCellDef>Level</th>
-                <td mat-cell *matCellDef="let book">
-                  <app-level-badge [level]="book.level" />
-                </td>
-              </ng-container>
-
-              <!-- Format Column -->
-              <ng-container matColumnDef="format">
-                <th mat-header-cell *matHeaderCellDef>Format</th>
-                <td mat-cell *matCellDef="let book">
-                  <span class="format-text">{{ book.format || '-' }}</span>
-                </td>
-              </ng-container>
-
-              <!-- Description Column -->
-              <ng-container matColumnDef="description">
-                <th mat-header-cell *matHeaderCellDef>Description</th>
-                <td mat-cell *matCellDef="let book">
-                  @if (book.description) {
-                    <app-truncated-text
-                      [text]="book.description"
-                      [maxLines]="1"
-                      class="description-text"
-                    />
-                  } @else {
-                    <span class="description-text">-</span>
-                  }
-                </td>
-              </ng-container>
-
-              <!-- Actions Column -->
-              <ng-container matColumnDef="actions">
-                <th mat-header-cell *matHeaderCellDef class="text-right">Actions</th>
-                <td mat-cell *matCellDef="let book" class="text-right">
-                  <button
-                    mat-icon-button
-                    class="action-button"
-                    aria-label="Send to Kindle"
-                    (click)="onSendToKindle($event, book)"
+            <table aria-label="Books" class="book-table">
+              <thead>
+                <tr>
+                  <th>ISBN</th>
+                  <th>Book Details</th>
+                  <th>Type / Category</th>
+                  <th class="text-center">Lang</th>
+                  <th>Level</th>
+                  <th>Format</th>
+                  <th>Description</th>
+                  <th class="text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (book of books(); track book.id) {
+                  <tr
+                    class="book-row"
+                    tabindex="0"
+                    (click)="onRowClick(book)"
+                    (keydown.enter)="onRowClick(book)"
                   >
-                    <mat-icon>send_to_mobile</mat-icon>
-                  </button>
-                </td>
-              </ng-container>
-
-              <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-              <tr
-                mat-row
-                *matRowDef="let row; columns: displayedColumns"
-                class="book-row"
-                tabindex="0"
-                (click)="onRowClick(row)"
-                (keydown.enter)="onRowClick(row)"
-              ></tr>
+                    <td class="isbn-column">
+                      <span class="isbn-text">{{ book.isbn || '-' }}</span>
+                    </td>
+                    <td class="title-column">
+                      <div class="title-cell">
+                        <span class="book-title">{{ book.title }}</span>
+                        <span class="book-author">{{ getAuthorNames(book) }}</span>
+                      </div>
+                    </td>
+                    <td class="type-category-column">
+                      <div class="type-category-cell">
+                        <span class="book-type">{{ book.type?.name || 'Unknown' }}</span>
+                        <app-category-chips [categories]="getCategoryNames(book)" [maxVisible]="1" />
+                      </div>
+                    </td>
+                    <td class="language-column text-center">
+                      <app-language-flag [languageCode]="book.language" />
+                    </td>
+                    <td class="level-column">
+                      <app-level-badge [level]="book.level" />
+                    </td>
+                    <td class="format-column">
+                      <span class="format-text">{{ book.format || '-' }}</span>
+                    </td>
+                    <td class="description-column">
+                      @if (book.description) {
+                        <app-truncated-text
+                          [text]="book.description"
+                          [maxLines]="1"
+                          class="description-text"
+                        />
+                      } @else {
+                        <span class="description-text">-</span>
+                      }
+                    </td>
+                    <td class="actions-column text-right">
+                      <button
+                        class="action-button"
+                        type="button"
+                        aria-label="Send to Kindle"
+                        title="Send to Kindle"
+                        (click)="onSendToKindle($event, book)"
+                      >
+                        <span class="material-symbols-outlined">send_to_mobile</span>
+                      </button>
+                    </td>
+                  </tr>
+                }
+              </tbody>
             </table>
           </div>
         </div>
@@ -235,16 +204,36 @@ import { Book } from '../../../../core/models/index.js';
     }
 
     .action-button {
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      padding: 0.5rem;
+      border-radius: 0.375rem;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
       color: #F1F5F9; /* slate-100 - FROM FIGMA for action icons */
-      transition: color 0.15s ease;
+      transition: all 0.15s ease;
 
       &:hover {
+        background-color: rgba(30, 41, 59, 0.5);
         color: #17a1cf; /* primary/cyan color */
+      }
+
+      &:focus-visible {
+        outline: 2px solid #3b82f6;
+        outline-offset: 2px;
+      }
+
+      .material-symbols-outlined {
+        font-size: 1.25rem;
+        width: 1.25rem;
+        height: 1.25rem;
       }
     }
 
     // Header cells styling - FROM FIGMA
-    th.mat-mdc-header-cell {
+    th {
       padding: 1rem 1.5rem; /* px-6 py-4 */
       font-size: 0.75rem; /* text-xs - 12px */
       font-weight: 600; /* font-semibold */
@@ -253,35 +242,36 @@ import { Book } from '../../../../core/models/index.js';
       color: #64748B; /* slate-500 - FROM FIGMA */
       background-color: rgba(30, 41, 59, 0.5); /* slate-800/50 - FROM FIGMA */
       border-bottom: 1px solid #334155; /* slate-700 - FROM FIGMA */
+      text-align: left;
     }
 
     // Body cells styling
-    td.mat-mdc-cell {
+    td {
       padding: 1rem 1.5rem; /* px-6 py-4 */
       vertical-align: middle;
     }
 
-    td.mat-column-actions {
+    .actions-column {
       width: 80px;
     }
 
-    td.mat-column-isbn {
+    .isbn-column {
       width: 140px;
     }
 
-    td.mat-column-language {
+    .language-column {
       width: 80px;
     }
 
-    td.mat-column-level {
+    .level-column {
       width: 140px;
     }
 
-    td.mat-column-format {
+    .format-column {
       width: 100px;
     }
 
-    td.mat-column-description {
+    .description-column {
       max-width: 250px;
     }
   `,
@@ -294,17 +284,6 @@ export class BookTableComponent {
 
   readonly rowClick = output<Book>();
   readonly sendToKindle = output<Book>();
-
-  readonly displayedColumns = [
-    'isbn',
-    'title',
-    'typeCategory',
-    'language',
-    'level',
-    'format',
-    'description',
-    'actions',
-  ];
 
   onRowClick(book: Book): void {
     this.rowClick.emit(book);


### PR DESCRIPTION
## Summary
Migrate the **book-table component** from Angular Material to native HTML `<table>` + TailwindCSS. This is the most **critical and complex** component in the application, handling the main book listing with multiple features.

## Component Migrated

### ✅ book-table
- **Removed**: `MatTableModule`, `MatButtonModule`, `MatIconModule`
- **Replaced**: `mat-table` → native `<table>` with `<thead>` and `<tbody>`
- **Replaced**: `mat-icon-button` + `mat-icon` → native `<button>` + Material Symbols
- **Structure**: 8 columns (ISBN, Title/Author, Type/Category, Language, Level, Format, Description, Actions)
- **Features**: Row click, action button (Send to Kindle), keyboard navigation, hover states

## Technical Changes

### Template
- **Before**: Material Table with `matColumnDef` + `*matHeaderCellDef` + `*matCellDef`
- **After**: Native HTML table with standard `<th>` and `<td>` elements
- **Data iteration**: Changed from `*matRowDef` to `@for (book of books(); track book.id)`
- **Icons**: Replaced `<mat-icon>send_to_mobile</mat-icon>` with `<span class="material-symbols-outlined">send_to_mobile</span>`
- **Button**: Added custom `.action-button` class with Tailwind hover/focus states

### TypeScript
- **Removed**: `displayedColumns` property (no longer needed with native table)
- **Maintained**: All input/output properties and helper methods (`getAuthorNames`, `getCategoryNames`)
- **0 Material imports**: Fully native with Angular standalone components

### Styles
- **Header cells**: Changed from `th.mat-mdc-header-cell` → `th` (with Figma colors: slate-500, slate-800/50 background)
- **Body cells**: Changed from `td.mat-mdc-cell` → `td`
- **Column widths**: Replaced `.mat-column-*` with custom classes (`.isbn-column`, `.actions-column`, etc.)
- **Action button**: Custom styling with transparent background, hover effect (slate-800/50), and color transition to primary cyan
- **Row hover**: Maintained slate-800/40 background on hover (from Figma design)
- **Focus states**: Added `focus-visible` outline for keyboard navigation

### Tests
- **Removed**: `NoopAnimationsModule` (no longer needed)
- **Updated selectors**:
  - `.mat-mdc-header-row` → `thead tr`
  - `.mat-mdc-row` → `tbody tr.book-row`
  - `mat-icon` → `.material-symbols-outlined`
- **New tests**:
  - Material Symbols icon rendering verification
  - Event propagation stopping (action button doesn't trigger row click)
  - Keyboard navigation (Enter key on row)
  - Column count verification (8 headers)
  - ISBN, format, and author display tests

## Components Used (Already Migrated)
- ✅ `category-chips` (Task #285)
- ✅ `level-badge` (Task #285)
- ✅ `language-flag` (Task #285)
- ✅ `truncated-text` (Task #285)
- ✅ `empty-state` (Task #285)
- ✅ `loading-overlay` (Task #285)

## Verification Checklist
- [ ] Table displays all books correctly
- [ ] All 8 columns render properly (ISBN, Title, Type/Category, Language, Level, Format, Description, Actions)
- [ ] Row click opens book detail (emits `rowClick` event)
- [ ] "Send to Kindle" button works (emits `sendToKindle` event)
- [ ] Hover states work on rows (slate-800/40 background)
- [ ] Hover states work on action button (background + color change)
- [ ] Focus states visible (keyboard navigation with Tab key)
- [ ] Empty state displays when no books
- [ ] Loading overlay displays when loading
- [ ] Material Symbols icon renders correctly (send_to_mobile)
- [ ] Tests pass: `npm test`
- [ ] No console errors
- [ ] Visual match with Figma design (dark mode)

## Related Issues
- Closes #287
- Part of #283 (HU-020: Migrate from Angular Material to TailwindCSS)

## Next Task
After this PR is merged: **Task #288 - Migrate filter components** (text-filter-input, semantic-search, searchable-select, multi-select-chips)

## Files Changed
- `apps/web-client/src/app/catalog/components/table/book-table/book-table.component.ts`
- `apps/web-client/src/app/catalog/components/table/book-table/book-table.component.spec.ts`

**Total**: 2 files, 175 insertions(+), 147 deletions(-)

## Design Reference
- Figma: `docs/web/designs/gestor_libros_-_dark_desktop/screen.png`
- Figma Table: `docs/web/designs/figma/table_container.svg`