### PR TITLE
Task #288: Migrate paginator component to ng-select + Tailwind

### DIFF
--- a/apps/web-client/src/app/catalog/components/table/paginator/paginator.component.spec.ts
+++ b/apps/web-client/src/app/catalog/components/table/paginator/paginator.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { PaginatorComponent } from './paginator.component';
 
 describe('PaginatorComponent', () => {
@@ -8,7 +7,7 @@ describe('PaginatorComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PaginatorComponent, NoopAnimationsModule],
+      imports: [PaginatorComponent],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PaginatorComponent);
@@ -125,10 +124,22 @@ describe('PaginatorComponent', () => {
       const loadMoreButton = fixture.nativeElement.querySelector(
         '[data-testid="load-more-button"]'
       );
-      const spinner = fixture.nativeElement.querySelector('mat-spinner');
+      const spinner = fixture.nativeElement.querySelector('.spinner');
 
       expect(loadMoreButton).toBeFalsy();
       expect(spinner).toBeTruthy();
+    });
+
+    it('should display Material Symbols icon in load more button', () => {
+      fixture.componentRef.setInput('totalCount', 100);
+      fixture.componentRef.setInput('currentCount', 25);
+      fixture.componentRef.setInput('hasNextPage', true);
+      fixture.componentRef.setInput('loading', false);
+      fixture.detectChanges();
+
+      const icon = fixture.nativeElement.querySelector('.load-more-button .material-symbols-outlined');
+      expect(icon).toBeTruthy();
+      expect(icon.textContent.trim()).toBe('expand_more');
     });
   });
 
@@ -171,8 +182,8 @@ describe('PaginatorComponent', () => {
       fixture.componentRef.setInput('loading', true);
       fixture.detectChanges();
 
-      const select = fixture.nativeElement.querySelector('mat-select');
-      expect(select.getAttribute('aria-disabled')).toBe('true');
+      const select = fixture.nativeElement.querySelector('ng-select');
+      expect(select.classList.contains('ng-select-disabled')).toBe(true);
     });
   });
 

--- a/apps/web-client/src/app/catalog/components/table/paginator/paginator.component.ts
+++ b/apps/web-client/src/app/catalog/components/table/paginator/paginator.component.ts
@@ -1,9 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { MatSelectModule } from '@angular/material/select';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { NgSelectModule } from '@ng-select/ng-select';
+import { FormsModule } from '@angular/forms';
 
 /**
  * PaginatorComponent - Cursor-based pagination with "load more" functionality
@@ -18,28 +15,22 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 @Component({
   selector: 'app-paginator',
   standalone: true,
-  imports: [
-    MatButtonModule,
-    MatIconModule,
-    MatSelectModule,
-    MatFormFieldModule,
-    MatProgressSpinnerModule,
-  ],
+  imports: [NgSelectModule, FormsModule],
   template: `
     <nav class="paginator" aria-label="Pagination">
       <div class="paginator-page-size">
         <span class="paginator-label">Items per page:</span>
-        <mat-form-field appearance="outline" class="paginator-select">
-          <mat-select
-            [value]="pageSize()"
-            [disabled]="loading()"
-            (selectionChange)="onPageSizeChange($event.value)"
-          >
-            @for (option of pageSizeOptions(); track option) {
-              <mat-option [value]="option">{{ option }}</mat-option>
-            }
-          </mat-select>
-        </mat-form-field>
+        <ng-select
+          class="paginator-select"
+          [items]="pageSizeOptions()"
+          [ngModel]="pageSize()"
+          [disabled]="loading()"
+          [searchable]="false"
+          [clearable]="false"
+          (ngModelChange)="onPageSizeChange($event)"
+          aria-label="Select items per page"
+        >
+        </ng-select>
       </div>
 
       <div class="paginator-range">
@@ -48,15 +39,20 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
       <div class="paginator-controls">
         @if (loading()) {
-          <mat-spinner diameter="24"></mat-spinner>
+          <div class="spinner" role="status" aria-label="Loading more items">
+            <svg class="spinner-icon" viewBox="0 0 24 24">
+              <circle class="spinner-circle" cx="12" cy="12" r="10" fill="none" stroke-width="3"></circle>
+            </svg>
+          </div>
         } @else if (hasNextPage()) {
           <button
-            mat-stroked-button
+            class="load-more-button"
+            type="button"
             data-testid="load-more-button"
             aria-label="Load more items"
             (click)="onLoadMore()"
           >
-            <mat-icon>expand_more</mat-icon>
+            <span class="material-symbols-outlined">expand_more</span>
             Load more
           </button>
         }
@@ -71,7 +67,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
       gap: 1rem;
       padding: 0.5rem 1rem;
       font-size: 0.875rem;
-      color: var(--mat-sys-on-surface-variant);
+      color: #94A3B8; /* slate-400 */
     }
 
     .paginator-page-size {
@@ -86,19 +82,6 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
     .paginator-select {
       width: 5rem;
-
-      ::ng-deep .mat-mdc-form-field-subscript-wrapper {
-        display: none;
-      }
-
-      ::ng-deep .mat-mdc-text-field-wrapper {
-        padding: 0 0.5rem;
-      }
-
-      ::ng-deep .mat-mdc-form-field-infix {
-        min-height: 2rem;
-        padding: 0.25rem 0;
-      }
     }
 
     .paginator-range {
@@ -112,8 +95,73 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
       justify-content: center;
     }
 
-    .paginator-controls button mat-icon {
-      margin-right: 4px;
+    .load-more-button {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.5rem 1rem;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: #17a1cf; /* primary color */
+      background-color: transparent;
+      border: 1px solid #17a1cf;
+      border-radius: 0.375rem;
+      cursor: pointer;
+      transition: all 0.15s ease;
+
+      &:hover {
+        background-color: rgba(23, 161, 207, 0.1);
+      }
+
+      &:focus-visible {
+        outline: 2px solid #3b82f6;
+        outline-offset: 2px;
+      }
+
+      .material-symbols-outlined {
+        font-size: 1.25rem;
+      }
+    }
+
+    .spinner {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .spinner-icon {
+      width: 24px;
+      height: 24px;
+      animation: spin 1s linear infinite;
+    }
+
+    .spinner-circle {
+      stroke: #17a1cf; /* primary color */
+      stroke-linecap: round;
+      stroke-dasharray: 50, 200;
+      stroke-dashoffset: 0;
+      animation: dash 1.5s ease-in-out infinite;
+    }
+
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
+
+    @keyframes dash {
+      0% {
+        stroke-dasharray: 1, 200;
+        stroke-dashoffset: 0;
+      }
+      50% {
+        stroke-dasharray: 100, 200;
+        stroke-dashoffset: -15;
+      }
+      100% {
+        stroke-dasharray: 100, 200;
+        stroke-dashoffset: -125;
+      }
     }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## Summary
Migrate the **paginator component** from Angular Material to `ng-select` + TailwindCSS with custom CSS spinner.

## Component Migrated

### ✅ paginator
- **Removed**: `MatButtonModule`, `MatIconModule`, `MatSelectModule`, `MatFormFieldModule`, `MatProgressSpinnerModule`
- **Replaced**: `mat-form-field` + `mat-select` → `ng-select`
- **Replaced**: `mat-stroked-button` + `mat-icon` → native `<button>` + Material Symbols
- **Replaced**: `mat-spinner` → custom CSS/SVG spinner
- **Features**: Cursor-based pagination, "Load more" button, page size selector, loading state

## Technical Changes

### Template
- **Before**: `mat-form-field` with `mat-select` for page size selection
- **After**: `ng-select` with `ngModel` binding (added `FormsModule`)
- **Button**: Replaced `mat-stroked-button` with native button + custom `.load-more-button` class
- **Icon**: Replaced `<mat-icon>expand_more</mat-icon>` with `<span class="material-symbols-outlined">expand_more</span>`
- **Spinner**: Replaced `<mat-spinner>` with custom SVG spinner with CSS animations

### TypeScript
- **Removed**: All Material module imports
- **Added**: `NgSelectModule` and `FormsModule`
- **Maintained**: All input/output properties, computed signals, and event handlers

### Styles
- **Removed**: All `::ng-deep` hacks (no longer needed)
- **Replaced**: Material color variables with Tailwind colors (slate-400 for text)
- **Custom button**: Added `.load-more-button` with:
  - Transparent background
  - Primary color border (#17a1cf)
  - Hover state with semi-transparent background
  - Focus-visible outline
  - Flexbox layout with icon + text
- **Custom spinner**: Added `.spinner`, `.spinner-icon`, `.spinner-circle` with:
  - Rotating animation (360deg in 1s)
  - Stroke dash animation for loading effect
  - Primary color stroke (#17a1cf)

### Tests
- **Removed**: `NoopAnimationsModule`
- **Updated selectors**:
  - `mat-spinner` → `.spinner`
  - `mat-select` → `ng-select`
  - Disabled check: `aria-disabled="true"` → `ng-select-disabled` class
- **New test**: Material Symbols icon rendering verification

## Verification Checklist
- [ ] Paginator displays correct count (e.g., "25 of 100")
- [ ] Page size selector works (ng-select dropdown)
- [ ] Page size selector is disabled when loading
- [ ] "Load more" button appears when hasNextPage is true
- [ ] "Load more" button emits loadMore event
- [ ] Spinner appears when loading (instead of button)
- [ ] Material Symbols icon renders correctly (expand_more)
- [ ] Button hover state works (background color change)
- [ ] Button focus state visible (keyboard navigation)
- [ ] Tests pass: `npm test`
- [ ] No console errors

## Related Issues
- Closes #288
- Part of #283 (HU-020: Migrate from Angular Material to TailwindCSS)

## Next Task
After this PR is merged: Continue with remaining filter/dialog/layout components

## Files Changed
- `apps/web-client/src/app/catalog/components/table/paginator/paginator.component.ts`
- `apps/web-client/src/app/catalog/components/table/paginator/paginator.component.spec.ts`

**Total**: 2 files, 106 insertions(+), 47 deletions(-)

## Notes
- Uses `ng-select` for page size selection (already configured in Task #284)
- Custom CSS spinner instead of `ngx-spinner` (simpler, no extra library needed for this use case)
- Maintains cursor-based pagination model (not offset-based)