### PR TITLE
HU-036: Envío de libro por email

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -25,3 +25,16 @@ AUTO_SEED=false
 BATCH_SIZE=50
 # Max retries for embedding service failures during seeding
 MAX_RETRIES=3
+
+# ----- Email service (Gmail) -----
+# Cuenta Gmail remitente para el envío de libros
+GMAIL_USER=biblioteca@gmail.com
+# Contraseña de aplicación de Google (no la contraseña normal de la cuenta)
+# Generar en: Google Account > Seguridad > Contraseñas de aplicación
+GMAIL_APP_PASSWORD=abcd efgh ijkl mnop
+
+# ----- Books file system -----
+# Ruta absoluta en el host donde residen los archivos de los libros
+# Los paths en la columna books.path son relativos a este directorio
+# Dentro del contenedor se monta en /books
+BOOKS_PATH=/ruta/a/tus/libros

--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -13,6 +13,7 @@
         "drizzle-kit": "^0.30.4",
         "drizzle-orm": "^0.38.3",
         "fastify": "^5.2.1",
+        "nodemailer": "^8.0.7",
         "pg": "^8.13.1",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
@@ -21,6 +22,7 @@
       "devDependencies": {
         "@eslint/js": "^9.18.0",
         "@types/node": "^22.10.7",
+        "@types/nodemailer": "^8.0.0",
         "@types/pg": "^8.11.10",
         "@vitest/coverage-v8": "^2.1.8",
         "@vitest/ui": "^2.1.8",
@@ -2025,6 +2027,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+      "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/pg": {
@@ -4241,6 +4253,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -32,17 +32,19 @@
   "dependencies": {
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^5.2.5",
+    "drizzle-kit": "^0.30.4",
     "drizzle-orm": "^0.38.3",
     "fastify": "^5.2.1",
+    "nodemailer": "^8.0.7",
     "pg": "^8.13.1",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
-    "drizzle-kit": "^0.30.4",
     "zod": "^3.24.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
     "@types/node": "^22.10.7",
+    "@types/nodemailer": "^8.0.0",
     "@types/pg": "^8.11.10",
     "@vitest/coverage-v8": "^2.1.8",
     "@vitest/ui": "^2.1.8",

--- a/apps/api/src/application/ports/EmailPort.ts
+++ b/apps/api/src/application/ports/EmailPort.ts
@@ -1,0 +1,39 @@
+/**
+ * EmailPort (Driven/Output Port)
+ *
+ * Defines the contract for sending emails with file attachments.
+ * This is a port in the hexagonal architecture - the actual implementation
+ * (e.g., NodemailerEmailAdapter) will be an adapter in the infrastructure layer.
+ */
+
+/**
+ * Options for sending an email with an attachment
+ */
+export interface SendEmailOptions {
+  /** Recipient email address */
+  to: string;
+  /** Email subject line */
+  subject: string;
+  /** Plain text body of the email */
+  body: string;
+  /** Absolute file system path to the attachment */
+  attachmentPath: string;
+  /** Filename to use for the attachment in the email */
+  attachmentFilename: string;
+}
+
+/**
+ * EmailPort Interface
+ *
+ * Provides operations for sending emails from the application.
+ */
+export interface EmailPort {
+  /**
+   * Sends an email with a single file attachment
+   *
+   * @param options - Email recipient, subject, body, and attachment details
+   * @returns Promise resolving when the email has been sent successfully
+   * @throws Error if the email could not be sent
+   */
+  sendWithAttachment(options: SendEmailOptions): Promise<void>;
+}

--- a/apps/api/src/application/ports/FileSystemPort.ts
+++ b/apps/api/src/application/ports/FileSystemPort.ts
@@ -1,0 +1,22 @@
+/**
+ * FileSystemPort (Driven/Output Port)
+ *
+ * Defines the contract for file system operations required by the application.
+ * This is a port in the hexagonal architecture - the actual implementation
+ * (e.g., NodeFileSystemAdapter) will be an adapter in the infrastructure layer.
+ */
+
+/**
+ * FileSystemPort Interface
+ *
+ * Provides operations for interacting with the file system.
+ */
+export interface FileSystemPort {
+  /**
+   * Checks whether a file exists at the given path
+   *
+   * @param path - Absolute path to the file
+   * @returns Promise resolving to true if the file exists, false otherwise
+   */
+  fileExists(path: string): Promise<boolean>;
+}

--- a/apps/api/src/application/use-cases/SendBookByEmailUseCase.ts
+++ b/apps/api/src/application/use-cases/SendBookByEmailUseCase.ts
@@ -1,0 +1,118 @@
+/**
+ * SendBookByEmailUseCase
+ *
+ * Application service that orchestrates sending a book file by email.
+ *
+ * Flow:
+ * 1. Validate the recipient email address
+ * 2. Find the book by its ID
+ * 3. Ensure the book has a file path defined
+ * 4. Build the absolute path using the configured books mount point
+ * 5. Verify the file exists on the file system
+ * 6. Send the email with the book file as attachment
+ *
+ * HU-036: Send book by email feature.
+ */
+
+import { posix as path } from 'node:path';
+import { EmailAddress } from '../../domain/value-objects/EmailAddress.js';
+import {
+  BookNotFoundError,
+  BookFileNotFoundError,
+} from '../../domain/errors/DomainErrors.js';
+import type { BookRepository } from '../ports/BookRepository.js';
+import type { FileSystemPort } from '../ports/FileSystemPort.js';
+import type { EmailPort } from '../ports/EmailPort.js';
+
+/**
+ * Input DTO for sending a book by email
+ */
+export interface SendBookByEmailInput {
+  /** UUID of the book to send */
+  bookId: string;
+  /** Recipient email address */
+  email: string;
+}
+
+/**
+ * Dependencies required by SendBookByEmailUseCase
+ */
+export interface SendBookByEmailUseCaseDeps {
+  bookRepository: BookRepository;
+  fileSystemPort: FileSystemPort;
+  emailPort: EmailPort;
+  /**
+   * Absolute path to the directory where books are stored.
+   * Defaults to '/books' (the Docker volume mount point).
+   */
+  booksMountPath?: string;
+}
+
+/**
+ * SendBookByEmailUseCase
+ *
+ * Orchestrates the complete flow for sending a book file to a recipient via email.
+ *
+ * The books directory is injected via `booksMountPath` (default: '/books') so the
+ * mount point is not hardcoded and can be overridden in tests or alternative deployments.
+ */
+export class SendBookByEmailUseCase {
+  private readonly bookRepository: BookRepository;
+  private readonly fileSystemPort: FileSystemPort;
+  private readonly emailPort: EmailPort;
+  private readonly booksMountPath: string;
+
+  constructor(deps: SendBookByEmailUseCaseDeps) {
+    this.bookRepository = deps.bookRepository;
+    this.fileSystemPort = deps.fileSystemPort;
+    this.emailPort = deps.emailPort;
+    this.booksMountPath = deps.booksMountPath ?? '/books';
+  }
+
+  /**
+   * Executes the send-book-by-email use case
+   *
+   * @param input - bookId and email of the recipient
+   * @returns Promise resolving when the email has been sent
+   * @throws InvalidEmailAddressError if the email is invalid
+   * @throws BookNotFoundError if no book exists with the given ID
+   * @throws BookFileNotFoundError if the book has no path or the file does not exist
+   * @throws EmailSendError if the email could not be delivered
+   */
+  async execute({ bookId, email }: SendBookByEmailInput): Promise<void> {
+    // 1. Validate email — throws InvalidEmailAddressError if invalid
+    const emailAddress = EmailAddress.create(email);
+
+    // 2. Find book — throws BookNotFoundError if not found
+    const book = await this.bookRepository.findById(bookId);
+    if (!book) {
+      throw new BookNotFoundError(bookId);
+    }
+
+    // 3. Ensure the book has a file path
+    if (!book.path) {
+      throw new BookFileNotFoundError(bookId);
+    }
+
+    // 4. Build absolute path inside the books mount point
+    const fullPath = path.join(this.booksMountPath, book.path);
+
+    // 5. Verify the file exists
+    const exists = await this.fileSystemPort.fileExists(fullPath);
+    if (!exists) {
+      throw new BookFileNotFoundError(bookId);
+    }
+
+    // 6. Compose author line for the email body
+    const authorNames = book.authors.map((a) => a.name).join(', ');
+
+    // 7. Send the email with the book as attachment
+    await this.emailPort.sendWithAttachment({
+      to: emailAddress.value,
+      subject: `[Library] ${book.title}`,
+      body: `Aquí tenés el libro que pediste:\n\nTítulo: ${book.title}\nAutor/es: ${authorNames}`,
+      attachmentPath: fullPath,
+      attachmentFilename: path.basename(book.path),
+    });
+  }
+}

--- a/apps/api/src/domain/errors/DomainErrors.ts
+++ b/apps/api/src/domain/errors/DomainErrors.ts
@@ -182,3 +182,24 @@ export class InvalidLanguageCodeError extends DomainError {
     );
   }
 }
+
+/**
+ * Thrown when a book's file is not found (no path defined or file does not exist)
+ */
+export class BookFileNotFoundError extends DomainError {
+  constructor(bookId: string) {
+    super(
+      `Book file not found for book "${bookId}". The book has no file path defined or the file does not exist.`,
+    );
+  }
+}
+
+/**
+ * Thrown when sending an email fails
+ */
+export class EmailSendError extends DomainError {
+  constructor(recipient: string, reason?: string) {
+    const reasonMessage = reason ? `: ${reason}` : '';
+    super(`Failed to send email to "${recipient}"${reasonMessage}`);
+  }
+}

--- a/apps/api/src/domain/errors/index.ts
+++ b/apps/api/src/domain/errors/index.ts
@@ -20,6 +20,8 @@ export {
   CategoryTypeMismatchError,
   LevelTypeMismatchError,
   InvalidLanguageCodeError,
+  BookFileNotFoundError,
+  EmailSendError,
 } from './DomainErrors.js';
 
 // Re-export Value Object errors for convenience
@@ -27,3 +29,4 @@ export { InvalidBookFormatError } from '../value-objects/BookFormat.js';
 export { InvalidBookIdentifierError } from '../value-objects/BookIdentifier.js';
 // InvalidISBNError re-exported for backward compatibility
 export { InvalidISBNError } from '../value-objects/ISBN.js';
+export { InvalidEmailAddressError } from '../value-objects/EmailAddress.js';

--- a/apps/api/src/domain/value-objects/EmailAddress.ts
+++ b/apps/api/src/domain/value-objects/EmailAddress.ts
@@ -1,0 +1,76 @@
+/**
+ * EmailAddress Value Object
+ *
+ * Represents a valid email address.
+ *
+ * Value Objects are:
+ * - Immutable
+ * - Compared by value, not identity
+ * - Self-validating
+ */
+
+import { DomainError } from '../errors/DomainErrors.js';
+
+export class EmailAddress {
+  private constructor(public readonly value: string) {
+    Object.freeze(this);
+  }
+
+  /**
+   * Creates a new EmailAddress instance
+   * @throws InvalidEmailAddressError if the value is not a valid email address
+   */
+  static create(value: string): EmailAddress {
+    if (!value || value.trim().length === 0) {
+      throw new InvalidEmailAddressError(value);
+    }
+
+    const trimmed = value.trim();
+
+    if (!EmailAddress.isValid(trimmed)) {
+      throw new InvalidEmailAddressError(value);
+    }
+
+    return new EmailAddress(trimmed);
+  }
+
+  /**
+   * Creates an EmailAddress from a known valid value (no validation)
+   * Use only when the value comes from a trusted source (e.g., database)
+   */
+  static fromPersistence(value: string): EmailAddress {
+    return new EmailAddress(value);
+  }
+
+  /**
+   * Validates an email address format
+   * Uses RFC 5322 simplified regex — no Zod, pure domain logic
+   */
+  static isValid(value: string): boolean {
+    // Simplified but robust email regex covering common cases
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(value);
+  }
+
+  /**
+   * Compares two EmailAddress instances
+   */
+  equals(other: EmailAddress): boolean {
+    return this.value === other.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}
+
+/**
+ * Error thrown when an invalid email address is provided
+ */
+export class InvalidEmailAddressError extends DomainError {
+  constructor(value: string) {
+    super(
+      `Invalid email address: "${value}". Must be a valid email format (e.g., user@example.com).`,
+    );
+  }
+}

--- a/apps/api/src/domain/value-objects/index.ts
+++ b/apps/api/src/domain/value-objects/index.ts
@@ -6,6 +6,7 @@ export { BookFormat, BOOK_FORMATS, type BookFormatValue, InvalidBookFormatError 
 export { BookIdentifier, InvalidBookIdentifierError } from './BookIdentifier.js';
 // ISBN re-exported for backward compatibility
 export { ISBN, InvalidISBNError } from './ISBN.js';
+export { EmailAddress, InvalidEmailAddressError } from './EmailAddress.js';
 
 // Re-export InvalidBookTypeError from errors for backward compatibility
 export { InvalidBookTypeError } from '../errors/DomainErrors.js';

--- a/apps/api/src/infrastructure/config/env.ts
+++ b/apps/api/src/infrastructure/config/env.ts
@@ -64,6 +64,16 @@ export interface AppConfig {
 }
 
 /**
+ * Gmail email service configuration (HU-036)
+ */
+export interface GmailConfig {
+  /** Gmail account used as sender */
+  user: string;
+  /** Google App Password (not the regular account password) */
+  appPassword: string;
+}
+
+/**
  * Complete environment configuration
  */
 export interface EnvConfig {
@@ -71,6 +81,7 @@ export interface EnvConfig {
   database: DatabaseConfig;
   ollama: OllamaConfig;
   translation: TranslationConfig; // HU-013
+  gmail: GmailConfig; // HU-036
 }
 
 /**
@@ -142,6 +153,24 @@ export function loadEnvConfig(): EnvConfig {
     );
   }
 
+  // HU-036: Validate Gmail credentials (required for book email delivery)
+  const gmailUser = process.env['GMAIL_USER'];
+  if (!gmailUser || gmailUser.trim() === '') {
+    throw new Error(
+      'GMAIL_USER environment variable is required but not set. ' +
+      'Please set it to the Gmail account used for sending books (e.g., biblioteca@gmail.com)',
+    );
+  }
+
+  const gmailAppPassword = process.env['GMAIL_APP_PASSWORD'];
+  if (!gmailAppPassword || gmailAppPassword.trim() === '') {
+    throw new Error(
+      'GMAIL_APP_PASSWORD environment variable is required but not set. ' +
+      'Please set it to a Google App Password (Google Account > Security > App Passwords). ' +
+      'Do NOT use your regular Gmail password.',
+    );
+  }
+
   return {
     app: {
       nodeEnv: process.env['NODE_ENV'] ?? DEFAULTS.NODE_ENV,
@@ -183,6 +212,11 @@ export function loadEnvConfig(): EnvConfig {
         DEFAULTS.LIBRETRANSLATE_TIMEOUT_MS,
         'LIBRETRANSLATE_TIMEOUT_MS',
       ),
+    },
+    // HU-036: Gmail email service configuration
+    gmail: {
+      user: gmailUser,
+      appPassword: gmailAppPassword,
     },
   };
 }

--- a/apps/api/src/infrastructure/driven/email/GmailEmailAdapter.ts
+++ b/apps/api/src/infrastructure/driven/email/GmailEmailAdapter.ts
@@ -1,0 +1,70 @@
+/**
+ * GmailEmailAdapter
+ *
+ * Implements the EmailPort using Nodemailer with Gmail's SMTP service.
+ * This is a driven/output adapter in the hexagonal architecture.
+ *
+ * Requires a Gmail account with an App Password (not the regular account password).
+ * See: https://support.google.com/accounts/answer/185833
+ */
+
+import nodemailer from 'nodemailer';
+import type { SendEmailOptions, EmailPort } from '../../../application/ports/EmailPort.js';
+import { EmailSendError } from '../../../domain/errors/DomainErrors.js';
+
+/**
+ * Configuration required to authenticate with Gmail SMTP
+ */
+export interface GmailConfig {
+  user: string;
+  appPassword: string;
+}
+
+/**
+ * GmailEmailAdapter
+ *
+ * Adapter that implements EmailPort using Nodemailer configured for Gmail.
+ */
+export class GmailEmailAdapter implements EmailPort {
+  private readonly transporter: nodemailer.Transporter;
+  private readonly user: string;
+
+  constructor(config: GmailConfig) {
+    this.user = config.user;
+    this.transporter = nodemailer.createTransport({
+      service: 'gmail',
+      auth: {
+        user: config.user,
+        pass: config.appPassword,
+      },
+    });
+  }
+
+  /**
+   * Sends an email with a file attachment via Gmail SMTP.
+   *
+   * @param options - Email recipient, subject, body, and attachment details
+   * @throws EmailSendError if Nodemailer fails to send the email
+   */
+  async sendWithAttachment(options: SendEmailOptions): Promise<void> {
+    const { to, subject, body, attachmentPath, attachmentFilename } = options;
+
+    try {
+      await this.transporter.sendMail({
+        from: this.user,
+        to,
+        subject,
+        text: body,
+        attachments: [
+          {
+            filename: attachmentFilename,
+            path: attachmentPath,
+          },
+        ],
+      });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : 'Unknown error';
+      throw new EmailSendError(to, reason);
+    }
+  }
+}

--- a/apps/api/src/infrastructure/driven/filesystem/NodeFileSystemAdapter.ts
+++ b/apps/api/src/infrastructure/driven/filesystem/NodeFileSystemAdapter.ts
@@ -1,0 +1,31 @@
+/**
+ * NodeFileSystemAdapter
+ *
+ * Implements the FileSystemPort using Node.js built-in fs/promises module.
+ * This is a driven/output adapter in the hexagonal architecture.
+ */
+
+import { access } from 'node:fs/promises';
+import type { FileSystemPort } from '../../../application/ports/FileSystemPort.js';
+
+/**
+ * NodeFileSystemAdapter
+ *
+ * Adapter that implements FileSystemPort using Node.js fs/promises.
+ */
+export class NodeFileSystemAdapter implements FileSystemPort {
+  /**
+   * Checks whether a file exists at the given path.
+   *
+   * @param path - Absolute file system path to check
+   * @returns Promise resolving to true if file exists, false otherwise
+   */
+  async fileExists(path: string): Promise<boolean> {
+    try {
+      await access(path);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/apps/api/src/infrastructure/driver/http/controllers/SendBookByEmailController.ts
+++ b/apps/api/src/infrastructure/driver/http/controllers/SendBookByEmailController.ts
@@ -1,0 +1,100 @@
+/**
+ * SendBookByEmailController
+ *
+ * HTTP request handler for the POST /api/books/:id/send endpoint.
+ * Follows the thin controller pattern - delegates business logic to the use case.
+ *
+ * HU-036: Send book by email feature.
+ */
+
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import type { SendBookByEmailUseCase } from '../../../../application/use-cases/SendBookByEmailUseCase.js';
+import type { Logger } from '../../../../application/ports/Logger.js';
+import { noopLogger } from '../../../../application/ports/Logger.js';
+import { sendBookByEmailSchema } from '../schemas/send-book.schemas.js';
+import { successResponse } from '../schemas/common.schemas.js';
+import { mapErrorToHttpResponse } from '../errors/HttpErrorMapper.js';
+
+/**
+ * Dependencies required by SendBookByEmailController
+ */
+export interface SendBookByEmailControllerDeps {
+  sendBookByEmailUseCase: SendBookByEmailUseCase;
+  logger?: Logger;
+}
+
+/**
+ * SendBookByEmailController
+ *
+ * Handles HTTP requests for sending a book by email.
+ */
+export class SendBookByEmailController {
+  private readonly sendBookByEmailUseCase: SendBookByEmailUseCase;
+  private readonly logger: Logger;
+
+  constructor(deps: SendBookByEmailControllerDeps) {
+    this.sendBookByEmailUseCase = deps.sendBookByEmailUseCase;
+    this.logger = deps.logger?.child({ name: 'SendBookByEmailController' }) ?? noopLogger;
+  }
+
+  /**
+   * POST /api/books/:id/send
+   *
+   * Sends a book file to the given email address.
+   *
+   * @returns 200 OK on success
+   * @returns 400 Bad Request for invalid email address
+   * @returns 404 Not Found if the book does not exist
+   * @returns 422 Unprocessable Entity if the book has no file or the file does not exist
+   * @returns 500 Internal Server Error if the email could not be sent
+   */
+  async send(
+    request: FastifyRequest<{ Params: { id: string } }>,
+    reply: FastifyReply,
+  ): Promise<FastifyReply> {
+    const bookId = request.params.id;
+
+    this.logger.debug('Received send book by email request', { bookId });
+
+    try {
+      // 1. Parse and validate request body
+      const parseResult = sendBookByEmailSchema.safeParse(request.body);
+
+      if (!parseResult.success) {
+        const errorResponse = mapErrorToHttpResponse(parseResult.error);
+        this.logger.debug('Request validation failed', {
+          errors: parseResult.error.errors.map((e) => e.message),
+        });
+        return reply.status(errorResponse.statusCode).send(errorResponse.body);
+      }
+
+      const { email } = parseResult.data;
+
+      // 2. Execute use case
+      await this.sendBookByEmailUseCase.execute({ bookId, email });
+
+      // 3. Return success
+      this.logger.info('Book sent by email', { bookId, email });
+
+      return reply.status(200).send(successResponse({ sent: true }));
+    } catch (error) {
+      const errorResponse = mapErrorToHttpResponse(error);
+
+      if (errorResponse.statusCode >= 500) {
+        this.logger.error('Unexpected error sending book by email', {
+          bookId,
+          error: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+        });
+      } else {
+        this.logger.debug('Send book by email rejected', {
+          bookId,
+          statusCode: errorResponse.statusCode,
+          error: errorResponse.body.error?.message,
+        });
+      }
+
+      return reply.status(errorResponse.statusCode).send(errorResponse.body);
+    }
+  }
+}

--- a/apps/api/src/infrastructure/driver/http/errors/HttpErrorMapper.ts
+++ b/apps/api/src/infrastructure/driver/http/errors/HttpErrorMapper.ts
@@ -20,7 +20,11 @@ import {
   EmbeddingTextTooLongError,
   CategoryTypeMismatchError,
   LevelTypeMismatchError,
+  BookNotFoundError,
+  BookFileNotFoundError,
+  EmailSendError,
 } from '../../../../domain/errors/DomainErrors.js';
+import { InvalidEmailAddressError } from '../../../../domain/value-objects/EmailAddress.js';
 import { InvalidBookIdentifierError } from '../../../../domain/value-objects/BookIdentifier.js';
 import { InvalidBookFormatError } from '../../../../domain/value-objects/BookFormat.js';
 import {
@@ -98,6 +102,26 @@ export function mapErrorToHttpResponse(error: unknown): HttpErrorResponse {
   // Zod validation errors
   if (error instanceof ZodError) {
     return mapZodError(error);
+  }
+
+  // HU-036: Invalid email address → 400
+  if (error instanceof InvalidEmailAddressError) {
+    return createErrorResponse(400, error.message);
+  }
+
+  // HU-036: Book not found → 404
+  if (error instanceof BookNotFoundError) {
+    return createErrorResponse(404, error.message);
+  }
+
+  // HU-036: Book file not found → 422
+  if (error instanceof BookFileNotFoundError) {
+    return createErrorResponse(422, error.message);
+  }
+
+  // HU-036: Email send error → 500
+  if (error instanceof EmailSendError) {
+    return createErrorResponse(500, error.message);
   }
 
   // Duplicate errors → 409 Conflict

--- a/apps/api/src/infrastructure/driver/http/routes/books.routes.ts
+++ b/apps/api/src/infrastructure/driver/http/routes/books.routes.ts
@@ -10,6 +10,7 @@
 import type { FastifyInstance, FastifyPluginOptions } from 'fastify';
 import type { BooksController } from '../controllers/BooksController.js';
 import type { SearchBooksController } from '../controllers/SearchBooksController.js';
+import type { SendBookByEmailController } from '../controllers/SendBookByEmailController.js';
 
 /**
  * Options for registering book routes
@@ -17,6 +18,7 @@ import type { SearchBooksController } from '../controllers/SearchBooksController
 export interface BooksRoutesOptions extends FastifyPluginOptions {
   controller: BooksController;
   searchController: SearchBooksController;
+  sendBookByEmailController: SendBookByEmailController;
 }
 
 /**
@@ -25,6 +27,7 @@ export interface BooksRoutesOptions extends FastifyPluginOptions {
  * Endpoints:
  * - GET /api/books - Search books with filters and pagination
  * - POST /api/books - Create a new book
+ * - POST /api/books/:id/send - Send a book by email (HU-036)
  *
  * @param fastify - Fastify instance
  * @param options - Route options including controllers
@@ -33,7 +36,7 @@ export async function booksRoutes(
   fastify: FastifyInstance,
   options: BooksRoutesOptions,
 ): Promise<void> {
-  const { controller, searchController } = options;
+  const { controller, searchController, sendBookByEmailController } = options;
 
   /**
    * GET /api/books
@@ -49,5 +52,16 @@ export async function booksRoutes(
    */
   fastify.post('/books', async (request, reply) => {
     return controller.create(request, reply);
+  });
+
+  /**
+   * POST /api/books/:id/send
+   * Sends a book file to the given email address (HU-036)
+   */
+  fastify.post('/books/:id/send', async (request, reply) => {
+    return sendBookByEmailController.send(
+      request as Parameters<typeof sendBookByEmailController.send>[0],
+      reply,
+    );
   });
 }

--- a/apps/api/src/infrastructure/driver/http/schemas/send-book.schemas.ts
+++ b/apps/api/src/infrastructure/driver/http/schemas/send-book.schemas.ts
@@ -1,0 +1,18 @@
+/**
+ * Send Book Validation Schemas
+ *
+ * Zod schemas for the POST /api/books/:id/send endpoint.
+ *
+ * HU-036: Send book by email feature.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Schema for sending a book by email via POST /api/books/:id/send
+ */
+export const sendBookByEmailSchema = z.object({
+  email: z.string().email('Must be a valid email address'),
+});
+
+export type SendBookByEmailBody = z.infer<typeof sendBookByEmailSchema>;

--- a/apps/api/src/infrastructure/driver/http/server.ts
+++ b/apps/api/src/infrastructure/driver/http/server.ts
@@ -23,6 +23,7 @@ import { SearchBooksController } from './controllers/SearchBooksController.js';
 import { BookTypesController } from './controllers/BookTypesController.js';
 import { CategoriesController } from './controllers/CategoriesController.js';
 import { BookLevelsController } from './controllers/BookLevelsController.js';
+import { SendBookByEmailController } from './controllers/SendBookByEmailController.js';
 import { booksRoutes } from './routes/books.routes.js';
 import { bookTypesRoutes } from './routes/book-types.routes.js';
 import { categoriesRoutes } from './routes/categories.routes.js';
@@ -32,6 +33,7 @@ import type { SearchBooksUseCase } from '../../../application/use-cases/SearchBo
 import type { ListBookTypesUseCase } from '../../../application/use-cases/ListBookTypesUseCase.js';
 import type { ListCategoriesUseCase } from '../../../application/use-cases/ListCategoriesUseCase.js';
 import type { ListBookLevelsUseCase } from '../../../application/use-cases/ListBookLevelsUseCase.js';
+import type { SendBookByEmailUseCase } from '../../../application/use-cases/SendBookByEmailUseCase.js';
 
 /**
  * Dependencies required by the server
@@ -42,6 +44,7 @@ export interface ServerDeps {
   listBookTypesUseCase: ListBookTypesUseCase;
   listCategoriesUseCase: ListCategoriesUseCase;
   listBookLevelsUseCase: ListBookLevelsUseCase;
+  sendBookByEmailUseCase: SendBookByEmailUseCase;
   logger?: Logger;
 }
 
@@ -66,7 +69,7 @@ export async function createServer(
   deps: ServerDeps,
   options: ServerOptions = {},
 ): Promise<FastifyInstance> {
-  const { createBookUseCase, searchBooksUseCase, listBookTypesUseCase, listCategoriesUseCase, listBookLevelsUseCase, logger = noopLogger } = deps;
+  const { createBookUseCase, searchBooksUseCase, listBookTypesUseCase, listCategoriesUseCase, listBookLevelsUseCase, sendBookByEmailUseCase, logger = noopLogger } = deps;
   const { prefix = '/api', nodeEnv = 'production' } = options;
 
   const serverLogger = logger.child({ name: 'FastifyServer' });
@@ -127,11 +130,17 @@ export async function createServer(
     logger,
   });
 
+  const sendBookByEmailController = new SendBookByEmailController({
+    sendBookByEmailUseCase,
+    logger,
+  });
+
   // Register routes with prefix
   await fastify.register(booksRoutes, {
     prefix,
     controller: booksController,
     searchController: searchBooksController,
+    sendBookByEmailController,
   });
 
   await fastify.register(bookTypesRoutes, {
@@ -154,6 +163,7 @@ export async function createServer(
     const routes = [
       { method: 'GET', path: `${prefix}/books` },
       { method: 'POST', path: `${prefix}/books` },
+      { method: 'POST', path: `${prefix}/books/:id/send` },
       { method: 'GET', path: `${prefix}/book-types` },
       { method: 'GET', path: `${prefix}/book-categories` },
       { method: 'GET', path: `${prefix}/book-levels` },

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -24,6 +24,9 @@ import { SearchBooksUseCase } from './application/use-cases/SearchBooksUseCase.j
 import { ListBookTypesUseCase } from './application/use-cases/ListBookTypesUseCase.js';
 import { ListCategoriesUseCase } from './application/use-cases/ListCategoriesUseCase.js';
 import { ListBookLevelsUseCase } from './application/use-cases/ListBookLevelsUseCase.js';
+import { SendBookByEmailUseCase } from './application/use-cases/SendBookByEmailUseCase.js';
+import { GmailEmailAdapter } from './infrastructure/driven/email/GmailEmailAdapter.js';
+import { NodeFileSystemAdapter } from './infrastructure/driven/filesystem/NodeFileSystemAdapter.js';
 import { createServer, startServer } from './infrastructure/driver/http/server.js';
 import * as schema from './infrastructure/driven/persistence/drizzle/schema.js';
 
@@ -122,9 +125,21 @@ async function bootstrap(): Promise<void> {
       logger,
     });
 
+    // HU-036: Send book by email use case
+    const emailAdapter = new GmailEmailAdapter({
+      user: env.gmail.user,
+      appPassword: env.gmail.appPassword,
+    });
+    const fileSystemAdapter = new NodeFileSystemAdapter();
+    const sendBookByEmailUseCase = new SendBookByEmailUseCase({
+      bookRepository,
+      fileSystemPort: fileSystemAdapter,
+      emailPort: emailAdapter,
+    });
+
     // Create and start server
     const server = await createServer(
-      { createBookUseCase, searchBooksUseCase, listBookTypesUseCase, listCategoriesUseCase, listBookLevelsUseCase, logger },
+      { createBookUseCase, searchBooksUseCase, listBookTypesUseCase, listCategoriesUseCase, listBookLevelsUseCase, sendBookByEmailUseCase, logger },
       { prefix: '/api', nodeEnv: env.app.nodeEnv },
     );
 

--- a/apps/api/tests/e2e/http/sendBookByEmail.e2e.test.ts
+++ b/apps/api/tests/e2e/http/sendBookByEmail.e2e.test.ts
@@ -1,0 +1,305 @@
+/**
+ * E2E Tests: POST /api/books/:id/send
+ *
+ * End-to-end tests for the send book by email API endpoint.
+ * These tests validate the complete HTTP flow.
+ *
+ * Tests cover:
+ * - Successful email send (200)
+ * - Invalid email address (400)
+ * - Book not found (404)
+ * - Book without file path or non-existent file (422)
+ *
+ * HU-036: Send book by email feature.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeFile, unlink } from 'node:fs/promises';
+import {
+  createE2EContext,
+  E2E_BASE_URL,
+} from '../setup.js';
+import type { EmailPort } from '../../../src/application/ports/EmailPort.js';
+import { PostgresBookRepository } from '../../../src/infrastructure/driven/persistence/PostgresBookRepository.js';
+import { PostgresCategoryRepository } from '../../../src/infrastructure/driven/persistence/PostgresCategoryRepository.js';
+import { PostgresTypeRepository } from '../../../src/infrastructure/driven/persistence/PostgresTypeRepository.js';
+import { PostgresAuthorRepository } from '../../../src/infrastructure/driven/persistence/PostgresAuthorRepository.js';
+import { PostgresLevelRepository } from '../../../src/infrastructure/driven/persistence/PostgresLevelRepository.js';
+import { OllamaEmbeddingService } from '../../../src/infrastructure/driven/embedding/OllamaEmbeddingService.js';
+import { LibreTranslateTranslationService } from '../../../src/infrastructure/driven/translation/LibreTranslateTranslationService.js';
+import { CreateBookUseCase } from '../../../src/application/use-cases/CreateBookUseCase.js';
+import { SearchBooksUseCase } from '../../../src/application/use-cases/SearchBooksUseCase.js';
+import { ListBookTypesUseCase } from '../../../src/application/use-cases/ListBookTypesUseCase.js';
+import { ListCategoriesUseCase } from '../../../src/application/use-cases/ListCategoriesUseCase.js';
+import { ListBookLevelsUseCase } from '../../../src/application/use-cases/ListBookLevelsUseCase.js';
+import { SendBookByEmailUseCase } from '../../../src/application/use-cases/SendBookByEmailUseCase.js';
+import { NodeFileSystemAdapter } from '../../../src/infrastructure/driven/filesystem/NodeFileSystemAdapter.js';
+import { createServer } from '../../../src/infrastructure/driver/http/server.js';
+import { noopLogger } from '../../../src/application/ports/Logger.js';
+import type { FastifyInstance } from 'fastify';
+import type { TestDb } from '../setup.js';
+
+const OLLAMA_EMBEDDING_URL =
+  process.env['OLLAMA_EMBEDDING_URL'] ??
+  process.env['OLLAMA_BASE_URL'] ??
+  process.env['OLLAMA_URL'] ??
+  'http://ollama-embeddings:11434';
+const LIBRETRANSLATE_URL =
+  process.env['LIBRETRANSLATE_URL'] ?? 'http://libretranslate-test:5000';
+const E2E_SERVER_PORT = 3099; // dedicated port for this test file
+const E2E_SERVER_HOST = '127.0.0.1';
+const BASE_URL = `http://${E2E_SERVER_HOST}:${E2E_SERVER_PORT}`;
+
+/**
+ * Creates a server for send-book tests, injecting a mock EmailPort and
+ * a configurable FileSystemPort (via booksMountPath override).
+ */
+async function createSendBookTestServer(
+  db: TestDb,
+  emailPort: EmailPort,
+  booksMountPath: string,
+): Promise<FastifyInstance> {
+  const ollamaModel = process.env['OLLAMA_MODEL'] ?? 'nomic-embed-text';
+
+  const embeddingService = new OllamaEmbeddingService({
+    baseUrl: OLLAMA_EMBEDDING_URL,
+    model: ollamaModel,
+    timeoutMs: 30000,
+  });
+  const translationService = new LibreTranslateTranslationService({
+    baseUrl: LIBRETRANSLATE_URL,
+    timeoutMs: 30000,
+    retries: 3,
+  });
+
+  const bookRepository = new PostgresBookRepository(db as any);
+  const categoryRepository = new PostgresCategoryRepository(db as any);
+  const typeRepository = new PostgresTypeRepository(db as any);
+  const authorRepository = new PostgresAuthorRepository(db as any);
+  const levelRepository = new PostgresLevelRepository(db as any);
+
+  const createBookUseCase = new CreateBookUseCase({
+    bookRepository,
+    categoryRepository,
+    typeRepository,
+    authorRepository,
+    levelRepository,
+    embeddingService,
+    translationService,
+    logger: noopLogger,
+  });
+
+  const searchBooksUseCase = new SearchBooksUseCase({
+    bookRepository,
+    embeddingService,
+    logger: noopLogger,
+  });
+
+  const listBookTypesUseCase = new ListBookTypesUseCase(typeRepository);
+  const listCategoriesUseCase = new ListCategoriesUseCase(categoryRepository, typeRepository);
+  const listBookLevelsUseCase = new ListBookLevelsUseCase(levelRepository, typeRepository);
+
+  const fileSystemAdapter = new NodeFileSystemAdapter();
+  const sendBookByEmailUseCase = new SendBookByEmailUseCase({
+    bookRepository,
+    fileSystemPort: fileSystemAdapter,
+    emailPort,
+    booksMountPath,
+  });
+
+  return createServer({
+    createBookUseCase,
+    searchBooksUseCase,
+    listBookTypesUseCase,
+    listCategoriesUseCase,
+    listBookLevelsUseCase,
+    sendBookByEmailUseCase,
+    logger: noopLogger,
+  });
+}
+
+describe('POST /api/books/:id/send', () => {
+  const ctx = createE2EContext();
+  let db: TestDb;
+  let sendWithAttachmentMock: ReturnType<typeof vi.fn>;
+  let emailPort: EmailPort;
+  let server: FastifyInstance;
+  let tmpBookPath: string;
+  let booksMountPath: string;
+  let createdBookId: string;
+  let bookIdWithoutPath: string;
+
+  beforeAll(async () => {
+    const result = await ctx.setup();
+    db = result.db;
+
+    // Create a real temp file to simulate a book
+    booksMountPath = tmpdir();
+    tmpBookPath = join(booksMountPath, 'test-e2e-book.pdf');
+    await writeFile(tmpBookPath, 'fake pdf content');
+
+    // Mock email port
+    sendWithAttachmentMock = vi.fn().mockResolvedValue(undefined);
+    emailPort = { sendWithAttachment: sendWithAttachmentMock };
+
+    server = await createSendBookTestServer(db, emailPort, booksMountPath);
+    await server.listen({ port: E2E_SERVER_PORT, host: E2E_SERVER_HOST });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    try { await unlink(tmpBookPath); } catch { /* ignore */ }
+    await ctx.teardown();
+  });
+
+  beforeEach(async () => {
+    await ctx.cleanup();
+    sendWithAttachmentMock.mockClear();
+
+    // Create a book WITH a file path (relative to booksMountPath)
+    const resWithPath = await fetch(`${BASE_URL}/api/books`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Send E2E Book',
+        authors: ['E2E Author'],
+        description: 'Libro de prueba para envío por email en tests E2E.',
+        type: 'technical',
+        format: 'pdf',
+        categories: ['E2E Testing'],
+        language: 'es',
+        available: true,
+        path: 'test-e2e-book.pdf',
+      }),
+    });
+    const bookData = await resWithPath.json() as { data: { id: string } };
+    createdBookId = bookData.data.id;
+
+    // Create a book WITHOUT a file path
+    const resWithoutPath = await fetch(`${BASE_URL}/api/books`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Send E2E Book Without Path',
+        authors: ['E2E Author'],
+        description: 'Libro de prueba sin path para tests E2E de envío.',
+        type: 'technical',
+        format: 'pdf',
+        categories: ['E2E Testing'],
+        language: 'es',
+        available: true,
+        path: null,
+      }),
+    });
+    const bookDataWithoutPath = await resWithoutPath.json() as { data: { id: string } };
+    bookIdWithoutPath = bookDataWithoutPath.data.id;
+  });
+
+  it('should return 200 and call email adapter when book exists with file', async () => {
+    const res = await fetch(`${BASE_URL}/api/books/${createdBookId}/send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'user@example.com' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean; data: { sent: boolean } };
+    expect(body.success).toBe(true);
+    expect(body.data.sent).toBe(true);
+    expect(sendWithAttachmentMock).toHaveBeenCalledOnce();
+    expect(sendWithAttachmentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'user@example.com' }),
+    );
+  });
+
+  it('should return 400 when email is invalid', async () => {
+    const res = await fetch(`${BASE_URL}/api/books/${createdBookId}/send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'not-an-email' }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { success: boolean; error: { message: string } };
+    expect(body.success).toBe(false);
+    expect(body.error).toBeDefined();
+    expect(sendWithAttachmentMock).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 when email field is missing', async () => {
+    const res = await fetch(`${BASE_URL}/api/books/${createdBookId}/send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { success: boolean };
+    expect(body.success).toBe(false);
+    expect(sendWithAttachmentMock).not.toHaveBeenCalled();
+  });
+
+  it('should return 404 when book does not exist', async () => {
+    const nonExistentId = '00000000-0000-0000-0000-000000000000';
+
+    const res = await fetch(`${BASE_URL}/api/books/${nonExistentId}/send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'user@example.com' }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json() as { success: boolean; error: { message: string } };
+    expect(body.success).toBe(false);
+    expect(body.error.message).toContain(nonExistentId);
+    expect(sendWithAttachmentMock).not.toHaveBeenCalled();
+  });
+
+  it('should return 422 when book has no file path', async () => {
+    const res = await fetch(`${BASE_URL}/api/books/${bookIdWithoutPath}/send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'user@example.com' }),
+    });
+
+    expect(res.status).toBe(422);
+    const body = await res.json() as { success: boolean; error: { message: string } };
+    expect(body.success).toBe(false);
+    expect(body.error.message).toContain(bookIdWithoutPath);
+    expect(sendWithAttachmentMock).not.toHaveBeenCalled();
+  });
+
+  it('should return 422 when book path points to a non-existent file', async () => {
+    // Create a book with a path to a file that does NOT exist
+    const resNonExistentFile = await fetch(`${BASE_URL}/api/books`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Book With Missing File',
+        authors: ['E2E Author'],
+        description: 'Libro con ruta a archivo que no existe.',
+        type: 'technical',
+        format: 'pdf',
+        categories: ['E2E Testing'],
+        language: 'es',
+        available: true,
+        path: 'nonexistent-file.pdf',
+      }),
+    });
+    const missingFileBook = await resNonExistentFile.json() as { data: { id: string } };
+    const missingFileBookId = missingFileBook.data.id;
+
+    const res = await fetch(`${BASE_URL}/api/books/${missingFileBookId}/send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'user@example.com' }),
+    });
+
+    expect(res.status).toBe(422);
+    const body = await res.json() as { success: boolean };
+    expect(body.success).toBe(false);
+    expect(sendWithAttachmentMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/tests/e2e/setup.ts
+++ b/apps/api/tests/e2e/setup.ts
@@ -21,6 +21,9 @@ import { SearchBooksUseCase } from '../../src/application/use-cases/SearchBooksU
 import { ListBookTypesUseCase } from '../../src/application/use-cases/ListBookTypesUseCase.js';
 import { ListCategoriesUseCase } from '../../src/application/use-cases/ListCategoriesUseCase.js';
 import { ListBookLevelsUseCase } from '../../src/application/use-cases/ListBookLevelsUseCase.js';
+import { SendBookByEmailUseCase } from '../../src/application/use-cases/SendBookByEmailUseCase.js';
+import { NodeFileSystemAdapter } from '../../src/infrastructure/driven/filesystem/NodeFileSystemAdapter.js';
+import type { EmailPort } from '../../src/application/ports/EmailPort.js';
 import { OllamaEmbeddingService } from '../../src/infrastructure/driven/embedding/OllamaEmbeddingService.js';
 import { LibreTranslateTranslationService } from '../../src/infrastructure/driven/translation/LibreTranslateTranslationService.js';
 import { PostgresBookRepository } from '../../src/infrastructure/driven/persistence/PostgresBookRepository.js';
@@ -96,7 +99,7 @@ export async function clearTestData(db: TestDb): Promise<void> {
 /**
  * Creates a fully configured Fastify server for E2E testing
  */
-export async function createTestServer(db: TestDb): Promise<FastifyInstance> {
+export async function createTestServer(db: TestDb, emailPort?: EmailPort): Promise<FastifyInstance> {
   const ollamaUrl = DEFAULT_OLLAMA_URL;
   const libretranslateUrl = DEFAULT_LIBRETRANSLATE_URL;
   const ollamaModel = process.env['OLLAMA_MODEL'] ?? DEFAULT_OLLAMA_MODEL;
@@ -158,6 +161,18 @@ export async function createTestServer(db: TestDb): Promise<FastifyInstance> {
     logger: noopLogger,
   });
 
+  // HU-036: Build a no-op email adapter unless a custom one is provided
+  const resolvedEmailPort: EmailPort = emailPort ?? {
+    sendWithAttachment: async () => { /* no-op for tests that don't test email */ },
+  };
+
+  const fileSystemAdapter = new NodeFileSystemAdapter();
+  const sendBookByEmailUseCase = new SendBookByEmailUseCase({
+    bookRepository,
+    fileSystemPort: fileSystemAdapter,
+    emailPort: resolvedEmailPort,
+  });
+
   // Create server
   const server = await createServer({
     createBookUseCase,
@@ -165,6 +180,7 @@ export async function createTestServer(db: TestDb): Promise<FastifyInstance> {
     listBookTypesUseCase,
     listCategoriesUseCase,
     listBookLevelsUseCase,
+    sendBookByEmailUseCase,
     logger: noopLogger,
   });
 

--- a/apps/api/tests/unit/application/ports/EmailPort.test.ts
+++ b/apps/api/tests/unit/application/ports/EmailPort.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { EmailPort, SendEmailOptions } from '../../../../src/application/ports/EmailPort.js';
+
+describe('EmailPort', () => {
+  describe('contract', () => {
+    it('should accept a mock implementation typed as EmailPort', () => {
+      const mock: EmailPort = {
+        sendWithAttachment: vi.fn().mockResolvedValue(undefined),
+      };
+
+      expect(mock).toBeDefined();
+      expect(typeof mock.sendWithAttachment).toBe('function');
+    });
+
+    it('should call sendWithAttachment with the correct options shape', async () => {
+      const mock: EmailPort = {
+        sendWithAttachment: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const options: SendEmailOptions = {
+        to: 'user@example.com',
+        subject: 'Your book',
+        body: 'Please find the book attached.',
+        attachmentPath: '/files/book.epub',
+        attachmentFilename: 'book.epub',
+      };
+
+      await mock.sendWithAttachment(options);
+
+      expect(mock.sendWithAttachment).toHaveBeenCalledOnce();
+      expect(mock.sendWithAttachment).toHaveBeenCalledWith(options);
+    });
+
+    it('should resolve to void on successful send', async () => {
+      const mock: EmailPort = {
+        sendWithAttachment: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const result = await mock.sendWithAttachment({
+        to: 'user@example.com',
+        subject: 'Your book',
+        body: 'Attached.',
+        attachmentPath: '/files/book.epub',
+        attachmentFilename: 'book.epub',
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should propagate errors thrown by the implementation', async () => {
+      const mock: EmailPort = {
+        sendWithAttachment: vi.fn().mockRejectedValue(new Error('SMTP connection failed')),
+      };
+
+      await expect(
+        mock.sendWithAttachment({
+          to: 'user@example.com',
+          subject: 'Subject',
+          body: 'Body',
+          attachmentPath: '/path/file.epub',
+          attachmentFilename: 'file.epub',
+        }),
+      ).rejects.toThrow('SMTP connection failed');
+    });
+  });
+});

--- a/apps/api/tests/unit/application/ports/FileSystemPort.test.ts
+++ b/apps/api/tests/unit/application/ports/FileSystemPort.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { FileSystemPort } from '../../../../src/application/ports/FileSystemPort.js';
+
+describe('FileSystemPort', () => {
+  describe('contract', () => {
+    it('should accept a mock implementation typed as FileSystemPort', () => {
+      const mock: FileSystemPort = {
+        fileExists: vi.fn().mockResolvedValue(true),
+      };
+
+      expect(mock).toBeDefined();
+      expect(typeof mock.fileExists).toBe('function');
+    });
+
+    it('should return true when the file exists', async () => {
+      const mock: FileSystemPort = {
+        fileExists: vi.fn().mockResolvedValue(true),
+      };
+
+      const result = await mock.fileExists('/files/book.epub');
+
+      expect(result).toBe(true);
+      expect(mock.fileExists).toHaveBeenCalledWith('/files/book.epub');
+    });
+
+    it('should return false when the file does not exist', async () => {
+      const mock: FileSystemPort = {
+        fileExists: vi.fn().mockResolvedValue(false),
+      };
+
+      const result = await mock.fileExists('/files/missing.epub');
+
+      expect(result).toBe(false);
+      expect(mock.fileExists).toHaveBeenCalledWith('/files/missing.epub');
+    });
+
+    it('should propagate errors thrown by the implementation', async () => {
+      const mock: FileSystemPort = {
+        fileExists: vi.fn().mockRejectedValue(new Error('Permission denied')),
+      };
+
+      await expect(mock.fileExists('/restricted/file.epub')).rejects.toThrow('Permission denied');
+    });
+  });
+});

--- a/apps/api/tests/unit/application/use-cases/SendBookByEmailUseCase.test.ts
+++ b/apps/api/tests/unit/application/use-cases/SendBookByEmailUseCase.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Unit Tests: SendBookByEmailUseCase
+ *
+ * Tests for the use case that sends a book file to a recipient via email.
+ * HU-036: Send book by email feature.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SendBookByEmailUseCase } from '../../../../src/application/use-cases/SendBookByEmailUseCase.js';
+import { Book } from '../../../../src/domain/entities/Book.js';
+import { BookType } from '../../../../src/domain/entities/BookType.js';
+import { Author } from '../../../../src/domain/entities/Author.js';
+import { InvalidEmailAddressError } from '../../../../src/domain/value-objects/EmailAddress.js';
+import {
+  BookNotFoundError,
+  BookFileNotFoundError,
+} from '../../../../src/domain/errors/DomainErrors.js';
+import type { BookRepository } from '../../../../src/application/ports/BookRepository.js';
+import type { FileSystemPort } from '../../../../src/application/ports/FileSystemPort.js';
+import type { EmailPort } from '../../../../src/application/ports/EmailPort.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const bookType = BookType.fromPersistence({
+  id: '550e8400-e29b-41d4-a716-446655440001',
+  name: 'technical',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+});
+
+const author = Author.fromPersistence({
+  id: '660e8400-e29b-41d4-a716-446655440001',
+  name: 'Robert C. Martin',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+});
+
+function makeBook(overrides: Partial<{ path: string | null }> = {}): Book {
+  return Book.fromPersistence({
+    id: '770e8400-e29b-41d4-a716-446655440001',
+    title: 'Clean Code',
+    authors: [author],
+    type: bookType,
+    categories: [],
+    format: 'epub',
+    isbn: null,
+    levelId: null,
+    originalDescription: 'A handbook of agile software craftsmanship.',
+    description: 'Un manual de artesanía de software ágil.',
+    language: 'en',
+    available: true,
+    path: overrides.path !== undefined ? overrides.path : 'clean-code.epub',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SendBookByEmailUseCase', () => {
+  let mockBookRepository: BookRepository;
+  let mockFileSystemPort: FileSystemPort;
+  let mockEmailPort: EmailPort;
+  let useCase: SendBookByEmailUseCase;
+
+  beforeEach(() => {
+    mockBookRepository = {
+      findById: vi.fn(),
+      findByIsbn: vi.fn(),
+      existsByIsbn: vi.fn(),
+      checkDuplicate: vi.fn(),
+      save: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      findAll: vi.fn(),
+      count: vi.fn(),
+      search: vi.fn(),
+    };
+
+    mockFileSystemPort = {
+      fileExists: vi.fn(),
+    };
+
+    mockEmailPort = {
+      sendWithAttachment: vi.fn(),
+    };
+
+    useCase = new SendBookByEmailUseCase({
+      bookRepository: mockBookRepository,
+      fileSystemPort: mockFileSystemPort,
+      emailPort: mockEmailPort,
+      booksMountPath: '/books',
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Email validation
+  // -------------------------------------------------------------------------
+
+  describe('email validation', () => {
+    it('should throw InvalidEmailAddressError when email is empty', async () => {
+      await expect(
+        useCase.execute({ bookId: 'any-id', email: '' }),
+      ).rejects.toThrow(InvalidEmailAddressError);
+    });
+
+    it('should throw InvalidEmailAddressError when email has no @', async () => {
+      await expect(
+        useCase.execute({ bookId: 'any-id', email: 'notanemail' }),
+      ).rejects.toThrow(InvalidEmailAddressError);
+    });
+
+    it('should throw InvalidEmailAddressError when email is malformed', async () => {
+      await expect(
+        useCase.execute({ bookId: 'any-id', email: 'bad@' }),
+      ).rejects.toThrow(InvalidEmailAddressError);
+    });
+
+    it('should not call the repository when the email is invalid', async () => {
+      await expect(
+        useCase.execute({ bookId: 'any-id', email: 'invalid' }),
+      ).rejects.toThrow(InvalidEmailAddressError);
+
+      expect(mockBookRepository.findById).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Book lookup
+  // -------------------------------------------------------------------------
+
+  describe('book lookup', () => {
+    it('should throw BookNotFoundError when the book does not exist', async () => {
+      vi.mocked(mockBookRepository.findById).mockResolvedValue(null);
+
+      await expect(
+        useCase.execute({ bookId: 'missing-id', email: 'user@example.com' }),
+      ).rejects.toThrow(BookNotFoundError);
+    });
+
+    it('should call findById with the given bookId', async () => {
+      vi.mocked(mockBookRepository.findById).mockResolvedValue(null);
+
+      await expect(
+        useCase.execute({ bookId: 'target-id', email: 'user@example.com' }),
+      ).rejects.toThrow(BookNotFoundError);
+
+      expect(mockBookRepository.findById).toHaveBeenCalledWith('target-id');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // File checks
+  // -------------------------------------------------------------------------
+
+  describe('file existence checks', () => {
+    it('should throw BookFileNotFoundError when the book has no path', async () => {
+      vi.mocked(mockBookRepository.findById).mockResolvedValue(makeBook({ path: null }));
+
+      await expect(
+        useCase.execute({ bookId: 'book-id', email: 'user@example.com' }),
+      ).rejects.toThrow(BookFileNotFoundError);
+    });
+
+    it('should not call fileExists when the book has no path', async () => {
+      vi.mocked(mockBookRepository.findById).mockResolvedValue(makeBook({ path: null }));
+
+      await expect(
+        useCase.execute({ bookId: 'book-id', email: 'user@example.com' }),
+      ).rejects.toThrow(BookFileNotFoundError);
+
+      expect(mockFileSystemPort.fileExists).not.toHaveBeenCalled();
+    });
+
+    it('should throw BookFileNotFoundError when the file does not exist on disk', async () => {
+      vi.mocked(mockBookRepository.findById).mockResolvedValue(makeBook());
+      vi.mocked(mockFileSystemPort.fileExists).mockResolvedValue(false);
+
+      await expect(
+        useCase.execute({ bookId: 'book-id', email: 'user@example.com' }),
+      ).rejects.toThrow(BookFileNotFoundError);
+    });
+
+    it('should call fileExists with the correct absolute path', async () => {
+      vi.mocked(mockBookRepository.findById).mockResolvedValue(makeBook({ path: 'clean-code.epub' }));
+      vi.mocked(mockFileSystemPort.fileExists).mockResolvedValue(false);
+
+      await expect(
+        useCase.execute({ bookId: 'book-id', email: 'user@example.com' }),
+      ).rejects.toThrow(BookFileNotFoundError);
+
+      expect(mockFileSystemPort.fileExists).toHaveBeenCalledWith('/books/clean-code.epub');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Happy path
+  // -------------------------------------------------------------------------
+
+  describe('happy path', () => {
+    it('should send the email with correct options', async () => {
+      vi.mocked(mockBookRepository.findById).mockResolvedValue(makeBook({ path: 'clean-code.epub' }));
+      vi.mocked(mockFileSystemPort.fileExists).mockResolvedValue(true);
+      vi.mocked(mockEmailPort.sendWithAttachment).mockResolvedValue(undefined);
+
+      await useCase.execute({ bookId: 'book-id', email: 'user@example.com' });
+
+      expect(mockEmailPort.sendWithAttachment).toHaveBeenCalledWith({
+        to: 'user@example.com',
+        subject: '[Library] Clean Code',
+        body: expect.stringContaining('Clean Code'),
+        attachmentPath: '/books/clean-code.epub',
+        attachmentFilename: 'clean-code.epub',
+      });
+    });
+
+    it('should include the author name in the email body', async () => {
+      vi.mocked(mockBookRepository.findById).mockResolvedValue(makeBook());
+      vi.mocked(mockFileSystemPort.fileExists).mockResolvedValue(true);
+      vi.mocked(mockEmailPort.sendWithAttachment).mockResolvedValue(undefined);
+
+      await useCase.execute({ bookId: 'book-id', email: 'user@example.com' });
+
+      const callArg = vi.mocked(mockEmailPort.sendWithAttachment).mock.calls[0][0];
+      expect(callArg.body).toContain('Robert C. Martin');
+    });
+
+    it('should resolve without error when everything succeeds', async () => {
+      vi.mocked(mockBookRepository.findById).mockResolvedValue(makeBook());
+      vi.mocked(mockFileSystemPort.fileExists).mockResolvedValue(true);
+      vi.mocked(mockEmailPort.sendWithAttachment).mockResolvedValue(undefined);
+
+      await expect(
+        useCase.execute({ bookId: 'book-id', email: 'user@example.com' }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should use the trimmed & lowercased email from EmailAddress VO', async () => {
+      vi.mocked(mockBookRepository.findById).mockResolvedValue(makeBook());
+      vi.mocked(mockFileSystemPort.fileExists).mockResolvedValue(true);
+      vi.mocked(mockEmailPort.sendWithAttachment).mockResolvedValue(undefined);
+
+      await useCase.execute({ bookId: 'book-id', email: '  user@example.com  ' });
+
+      const callArg = vi.mocked(mockEmailPort.sendWithAttachment).mock.calls[0][0];
+      expect(callArg.to).toBe('user@example.com');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // booksMountPath configuration
+  // -------------------------------------------------------------------------
+
+  describe('booksMountPath configuration', () => {
+    it('should default to /books when no booksMountPath is provided', async () => {
+      const useCaseDefault = new SendBookByEmailUseCase({
+        bookRepository: mockBookRepository,
+        fileSystemPort: mockFileSystemPort,
+        emailPort: mockEmailPort,
+      });
+
+      vi.mocked(mockBookRepository.findById).mockResolvedValue(makeBook({ path: 'book.epub' }));
+      vi.mocked(mockFileSystemPort.fileExists).mockResolvedValue(true);
+      vi.mocked(mockEmailPort.sendWithAttachment).mockResolvedValue(undefined);
+
+      await useCaseDefault.execute({ bookId: 'book-id', email: 'user@example.com' });
+
+      expect(mockFileSystemPort.fileExists).toHaveBeenCalledWith('/books/book.epub');
+    });
+
+    it('should use a custom booksMountPath when provided', async () => {
+      const useCaseCustom = new SendBookByEmailUseCase({
+        bookRepository: mockBookRepository,
+        fileSystemPort: mockFileSystemPort,
+        emailPort: mockEmailPort,
+        booksMountPath: '/custom/library',
+      });
+
+      vi.mocked(mockBookRepository.findById).mockResolvedValue(makeBook({ path: 'book.epub' }));
+      vi.mocked(mockFileSystemPort.fileExists).mockResolvedValue(true);
+      vi.mocked(mockEmailPort.sendWithAttachment).mockResolvedValue(undefined);
+
+      await useCaseCustom.execute({ bookId: 'book-id', email: 'user@example.com' });
+
+      expect(mockFileSystemPort.fileExists).toHaveBeenCalledWith('/custom/library/book.epub');
+      expect(vi.mocked(mockEmailPort.sendWithAttachment).mock.calls[0][0].attachmentPath).toBe(
+        '/custom/library/book.epub',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error propagation
+  // -------------------------------------------------------------------------
+
+  describe('error propagation', () => {
+    it('should propagate errors thrown by emailPort.sendWithAttachment', async () => {
+      vi.mocked(mockBookRepository.findById).mockResolvedValue(makeBook());
+      vi.mocked(mockFileSystemPort.fileExists).mockResolvedValue(true);
+      vi.mocked(mockEmailPort.sendWithAttachment).mockRejectedValue(
+        new Error('SMTP connection refused'),
+      );
+
+      await expect(
+        useCase.execute({ bookId: 'book-id', email: 'user@example.com' }),
+      ).rejects.toThrow('SMTP connection refused');
+    });
+
+    it('should propagate errors thrown by bookRepository.findById', async () => {
+      vi.mocked(mockBookRepository.findById).mockRejectedValue(new Error('DB unavailable'));
+
+      await expect(
+        useCase.execute({ bookId: 'book-id', email: 'user@example.com' }),
+      ).rejects.toThrow('DB unavailable');
+    });
+  });
+});

--- a/apps/api/tests/unit/domain/value-objects/DomainEmailErrors.test.ts
+++ b/apps/api/tests/unit/domain/value-objects/DomainEmailErrors.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BookFileNotFoundError,
+  EmailSendError,
+} from '../../../../src/domain/errors/DomainErrors.js';
+
+describe('BookFileNotFoundError', () => {
+  it('should create error with correct message', () => {
+    const error = new BookFileNotFoundError('book-123');
+    expect(error.message).toContain('book-123');
+    expect(error.message).toContain('file not found');
+  });
+
+  it('should have the correct name', () => {
+    const error = new BookFileNotFoundError('book-123');
+    expect(error.name).toBe('BookFileNotFoundError');
+  });
+
+  it('should be an instance of Error', () => {
+    const error = new BookFileNotFoundError('book-123');
+    expect(error).toBeInstanceOf(Error);
+  });
+});
+
+describe('EmailSendError', () => {
+  it('should create error with recipient and no reason', () => {
+    const error = new EmailSendError('user@example.com');
+    expect(error.message).toContain('user@example.com');
+  });
+
+  it('should create error with recipient and reason', () => {
+    const error = new EmailSendError('user@example.com', 'connection refused');
+    expect(error.message).toContain('user@example.com');
+    expect(error.message).toContain('connection refused');
+  });
+
+  it('should have the correct name', () => {
+    const error = new EmailSendError('user@example.com');
+    expect(error.name).toBe('EmailSendError');
+  });
+
+  it('should be an instance of Error', () => {
+    const error = new EmailSendError('user@example.com');
+    expect(error).toBeInstanceOf(Error);
+  });
+});

--- a/apps/api/tests/unit/domain/value-objects/EmailAddress.test.ts
+++ b/apps/api/tests/unit/domain/value-objects/EmailAddress.test.ts
@@ -117,4 +117,11 @@ describe('EmailAddress', () => {
       expect(Object.isFrozen(email)).toBe(true);
     });
   });
+
+  describe('toString', () => {
+    it('should return the email value as string', () => {
+      const email = EmailAddress.create('user@example.com');
+      expect(email.toString()).toBe('user@example.com');
+    });
+  });
 });

--- a/apps/api/tests/unit/domain/value-objects/EmailAddress.test.ts
+++ b/apps/api/tests/unit/domain/value-objects/EmailAddress.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EmailAddress,
+  InvalidEmailAddressError,
+} from '../../../../src/domain/value-objects/EmailAddress.js';
+
+describe('EmailAddress', () => {
+  describe('create', () => {
+    describe('valid emails', () => {
+      it('should create a valid email address', () => {
+        const email = EmailAddress.create('user@example.com');
+        expect(email.value).toBe('user@example.com');
+      });
+
+      it('should trim whitespace from email', () => {
+        const email = EmailAddress.create('  user@example.com  ');
+        expect(email.value).toBe('user@example.com');
+      });
+
+      it('should accept email with subdomain', () => {
+        const email = EmailAddress.create('user@mail.example.com');
+        expect(email.value).toBe('user@mail.example.com');
+      });
+
+      it('should accept email with plus sign in local part', () => {
+        const email = EmailAddress.create('user+tag@example.com');
+        expect(email.value).toBe('user+tag@example.com');
+      });
+
+      it('should accept email with dots in local part', () => {
+        const email = EmailAddress.create('first.last@example.com');
+        expect(email.value).toBe('first.last@example.com');
+      });
+    });
+
+    describe('invalid emails', () => {
+      it('should throw InvalidEmailAddressError for empty string', () => {
+        expect(() => EmailAddress.create('')).toThrow(InvalidEmailAddressError);
+      });
+
+      it('should throw InvalidEmailAddressError for whitespace-only string', () => {
+        expect(() => EmailAddress.create('   ')).toThrow(
+          InvalidEmailAddressError,
+        );
+      });
+
+      it('should throw InvalidEmailAddressError for missing @ symbol', () => {
+        expect(() => EmailAddress.create('userexample.com')).toThrow(
+          InvalidEmailAddressError,
+        );
+      });
+
+      it('should throw InvalidEmailAddressError for missing domain', () => {
+        expect(() => EmailAddress.create('user@')).toThrow(
+          InvalidEmailAddressError,
+        );
+      });
+
+      it('should throw InvalidEmailAddressError for missing TLD', () => {
+        expect(() => EmailAddress.create('user@example')).toThrow(
+          InvalidEmailAddressError,
+        );
+      });
+
+      it('should throw InvalidEmailAddressError for email with spaces', () => {
+        expect(() => EmailAddress.create('user name@example.com')).toThrow(
+          InvalidEmailAddressError,
+        );
+      });
+
+      it('should throw InvalidEmailAddressError for double @ symbols', () => {
+        expect(() => EmailAddress.create('user@@example.com')).toThrow(
+          InvalidEmailAddressError,
+        );
+      });
+    });
+  });
+
+  describe('fromPersistence', () => {
+    it('should create EmailAddress from persistence without validation', () => {
+      const email = EmailAddress.fromPersistence('any-value@stored.com');
+      expect(email.value).toBe('any-value@stored.com');
+    });
+  });
+
+  describe('isValid', () => {
+    it('should return true for a valid email', () => {
+      expect(EmailAddress.isValid('user@example.com')).toBe(true);
+    });
+
+    it('should return false for an email without @', () => {
+      expect(EmailAddress.isValid('userexample.com')).toBe(false);
+    });
+
+    it('should return false for an email without TLD', () => {
+      expect(EmailAddress.isValid('user@example')).toBe(false);
+    });
+  });
+
+  describe('equals', () => {
+    it('should return true for two EmailAddress instances with same value', () => {
+      const email1 = EmailAddress.create('user@example.com');
+      const email2 = EmailAddress.create('user@example.com');
+      expect(email1.equals(email2)).toBe(true);
+    });
+
+    it('should return false for two EmailAddress instances with different values', () => {
+      const email1 = EmailAddress.create('user@example.com');
+      const email2 = EmailAddress.create('other@example.com');
+      expect(email1.equals(email2)).toBe(false);
+    });
+  });
+
+  describe('immutability', () => {
+    it('should be frozen (immutable)', () => {
+      const email = EmailAddress.create('user@example.com');
+      expect(Object.isFrozen(email)).toBe(true);
+    });
+  });
+});

--- a/apps/api/tests/unit/infrastructure/config/env.test.ts
+++ b/apps/api/tests/unit/infrastructure/config/env.test.ts
@@ -27,6 +27,8 @@ describe('Environment Configuration', () => {
       process.env['OLLAMA_TRANSLATION_URL'] = 'http://localhost:11435';
       process.env['OLLAMA_MODEL'] = 'test-model';
       process.env['OLLAMA_TIMEOUT_MS'] = '15000';
+      process.env['GMAIL_USER'] = 'test@gmail.com';
+      process.env['GMAIL_APP_PASSWORD'] = 'abcd efgh ijkl mnop';
 
       const config = loadEnvConfig();
 
@@ -42,6 +44,8 @@ describe('Environment Configuration', () => {
 
     it('should use default values when optional environment variables are not set', () => {
       process.env['DATABASE_URL'] = 'postgresql://test:test@localhost:5432/testdb';
+      process.env['GMAIL_USER'] = 'test@gmail.com';
+      process.env['GMAIL_APP_PASSWORD'] = 'abcd efgh ijkl mnop';
       // Clear optional environment variables
       delete process.env['NODE_ENV'];
       delete process.env['PORT'];
@@ -99,6 +103,8 @@ describe('Environment Configuration', () => {
   describe('TRANSLATION_PROVIDER (HU-026)', () => {
     beforeEach(() => {
       process.env['DATABASE_URL'] = 'postgresql://test:test@localhost:5432/testdb';
+      process.env['GMAIL_USER'] = 'test@gmail.com';
+      process.env['GMAIL_APP_PASSWORD'] = 'abcd efgh ijkl mnop';
     });
 
     it('should default TRANSLATION_PROVIDER to "ollama" when not set', () => {
@@ -180,177 +186,87 @@ describe('Environment Configuration', () => {
     });
   });
 
-  describe('getOllamaConfig', () => {
-    it('should return Ollama configuration when DATABASE_URL is set', () => {
+  describe('Gmail configuration (HU-036)', () => {
+    beforeEach(() => {
       process.env['DATABASE_URL'] = 'postgresql://test:test@localhost:5432/testdb';
-      process.env['OLLAMA_EMBEDDING_URL'] = 'http://custom:11434';
-      process.env['OLLAMA_MODEL'] = 'custom-model';
-      process.env['OLLAMA_TIMEOUT_MS'] = '20000';
-
-      const config = getOllamaConfig();
-
-      expect(config).toEqual({
-        baseUrl: 'http://custom:11434',
-        model: 'custom-model',
-        timeoutMs: 20000,
-      });
     });
 
-    it('should return default Ollama configuration when no env vars set', () => {
-      process.env['DATABASE_URL'] = 'postgresql://test:test@localhost:5432/testdb';
-      delete process.env['OLLAMA_EMBEDDING_URL'];
-      delete process.env['OLLAMA_MODEL'];
-      delete process.env['OLLAMA_TIMEOUT_MS'];
-
-      const config = getOllamaConfig();
-
-      expect(config).toEqual({
-        baseUrl: 'http://ollama-embeddings:11434',
-        model: 'nomic-embed-text',
-        timeoutMs: 30000,
-      });
-    });
-
-    it('should throw error if OLLAMA_TIMEOUT_MS is invalid', () => {
-      process.env['DATABASE_URL'] = 'postgresql://test:test@localhost:5432/testdb';
-      process.env['OLLAMA_TIMEOUT_MS'] = 'bad-value';
-
-      expect(() => getOllamaConfig()).toThrow(
-        'Invalid integer value for OLLAMA_TIMEOUT_MS: "bad-value". Expected a valid number.'
-      );
-    });
-
-    it('should throw error if OLLAMA_TIMEOUT_MS contains partial number with trailing text', () => {
-      process.env['DATABASE_URL'] = 'postgresql://test:test@localhost:5432/testdb';
-      process.env['OLLAMA_TIMEOUT_MS'] = '15000ms';
-
-      expect(() => loadEnvConfig()).toThrow(
-        'Invalid integer value for OLLAMA_TIMEOUT_MS: "15000ms". Expected a valid number.'
-      );
-    });
-
-    it('should throw error if PORT contains partial number with trailing text', () => {
-      process.env['DATABASE_URL'] = 'postgresql://test:test@localhost:5432/testdb';
-      process.env['PORT'] = '3000px';
-
-      expect(() => loadEnvConfig()).toThrow(
-        'Invalid integer value for PORT: "3000px". Expected a valid number.'
-      );
-    });
-
-    it('should throw error if PORT contains leading text', () => {
-      process.env['DATABASE_URL'] = 'postgresql://test:test@localhost:5432/testdb';
-      process.env['PORT'] = 'port3000';
-
-      expect(() => loadEnvConfig()).toThrow(
-        'Invalid integer value for PORT: "port3000". Expected a valid number.'
-      );
-    });
-
-    it('should throw error if integer value contains decimal', () => {
-      process.env['DATABASE_URL'] = 'postgresql://test:test@localhost:5432/testdb';
-      process.env['PORT'] = '3000.5';
-
-      expect(() => loadEnvConfig()).toThrow(
-        'Invalid integer value for PORT: "3000.5". Expected a valid number.'
-      );
-    });
-  });
-});
-
-describe('Environment Configuration', () => {
-  let originalEnv: NodeJS.ProcessEnv;
-
-  beforeEach(() => {
-    // Save original environment
-    originalEnv = { ...process.env };
-  });
-
-  afterEach(() => {
-    // Restore original environment
-    process.env = originalEnv;
-  });
-
-  describe('loadEnvConfig', () => {
-    it('should load configuration with all environment variables set', () => {
-      process.env['NODE_ENV'] = 'test';
-      process.env['PORT'] = '4000';
-      process.env['LOG_LEVEL'] = 'info';
-      process.env['DATABASE_URL'] = 'postgresql://test:test@localhost:5432/testdb';
-      process.env['OLLAMA_EMBEDDING_URL'] = 'http://localhost:11434';
-      process.env['OLLAMA_TRANSLATION_URL'] = 'http://localhost:11435';
-      process.env['OLLAMA_MODEL'] = 'test-model';
-      process.env['OLLAMA_TIMEOUT_MS'] = '15000';
+    it('should load gmail config when GMAIL_USER and GMAIL_APP_PASSWORD are set', () => {
+      process.env['GMAIL_USER'] = 'biblioteca@gmail.com';
+      process.env['GMAIL_APP_PASSWORD'] = 'abcd efgh ijkl mnop';
 
       const config = loadEnvConfig();
 
-      expect(config.app.nodeEnv).toBe('test');
-      expect(config.app.port).toBe(4000);
-      expect(config.app.logLevel).toBe('info');
-      expect(config.database.url).toBe('postgresql://test:test@localhost:5432/testdb');
-      expect(config.ollama.baseUrl).toBe('http://localhost:11434');
-      expect(config.ollama.model).toBe('test-model');
-      expect(config.ollama.timeoutMs).toBe(15000);
-      expect(config.translation.baseUrl).toBe('http://localhost:11435');
+      expect(config.gmail.user).toBe('biblioteca@gmail.com');
+      expect(config.gmail.appPassword).toBe('abcd efgh ijkl mnop');
     });
 
-    it('should use default values when optional environment variables are not set', () => {
-      process.env['DATABASE_URL'] = 'postgresql://test:test@localhost:5432/testdb';
-      // Clear optional environment variables
-      delete process.env['NODE_ENV'];
-      delete process.env['PORT'];
-      delete process.env['LOG_LEVEL'];
-      delete process.env['OLLAMA_EMBEDDING_URL'];
-      delete process.env['OLLAMA_TRANSLATION_URL'];
-      delete process.env['OLLAMA_MODEL'];
-      delete process.env['OLLAMA_TIMEOUT_MS'];
-
-      const config = loadEnvConfig();
-
-      expect(config.app.nodeEnv).toBe('development');
-      expect(config.app.port).toBe(3000);
-      expect(config.app.logLevel).toBe('debug');
-      expect(config.database.url).toBe('postgresql://test:test@localhost:5432/testdb');
-      expect(config.ollama.baseUrl).toBe('http://ollama-embeddings:11434');
-      expect(config.ollama.model).toBe('nomic-embed-text');
-      expect(config.ollama.timeoutMs).toBe(30000);
-      expect(config.translation.baseUrl).toBe('http://ollama-translations:11435');
-    });
-
-    it('should throw error when DATABASE_URL is not set', () => {
-      delete process.env['DATABASE_URL'];
+    it('should throw error when GMAIL_USER is not set', () => {
+      delete process.env['GMAIL_USER'];
+      process.env['GMAIL_APP_PASSWORD'] = 'abcd efgh ijkl mnop';
 
       expect(() => loadEnvConfig()).toThrow(
-        'DATABASE_URL environment variable is required but not set'
+        'GMAIL_USER environment variable is required but not set',
       );
     });
 
-    it('should throw error when DATABASE_URL is empty string', () => {
-      process.env['DATABASE_URL'] = '';
+    it('should throw error when GMAIL_USER is empty string', () => {
+      process.env['GMAIL_USER'] = '';
+      process.env['GMAIL_APP_PASSWORD'] = 'abcd efgh ijkl mnop';
 
       expect(() => loadEnvConfig()).toThrow(
-        'DATABASE_URL environment variable is required but not set'
+        'GMAIL_USER environment variable is required but not set',
       );
     });
 
-    it('should throw error when DATABASE_URL is only whitespace', () => {
-      process.env['DATABASE_URL'] = '   ';
+    it('should throw error when GMAIL_USER is only whitespace', () => {
+      process.env['GMAIL_USER'] = '   ';
+      process.env['GMAIL_APP_PASSWORD'] = 'abcd efgh ijkl mnop';
 
       expect(() => loadEnvConfig()).toThrow(
-        'DATABASE_URL environment variable is required but not set'
+        'GMAIL_USER environment variable is required but not set',
       );
     });
 
-    it('should include helpful error message with example connection string', () => {
-      delete process.env['DATABASE_URL'];
+    it('should include helpful example in GMAIL_USER error message', () => {
+      delete process.env['GMAIL_USER'];
+      process.env['GMAIL_APP_PASSWORD'] = 'abcd efgh ijkl mnop';
+
+      expect(() => loadEnvConfig()).toThrow(/biblioteca@gmail\.com/);
+    });
+
+    it('should throw error when GMAIL_APP_PASSWORD is not set', () => {
+      process.env['GMAIL_USER'] = 'biblioteca@gmail.com';
+      delete process.env['GMAIL_APP_PASSWORD'];
 
       expect(() => loadEnvConfig()).toThrow(
-        /Please set it in your environment or \.env file \(e\.g\., postgresql:\/\/user:password@host:5432\/database\)/
+        'GMAIL_APP_PASSWORD environment variable is required but not set',
       );
+    });
+
+    it('should throw error when GMAIL_APP_PASSWORD is empty string', () => {
+      process.env['GMAIL_USER'] = 'biblioteca@gmail.com';
+      process.env['GMAIL_APP_PASSWORD'] = '';
+
+      expect(() => loadEnvConfig()).toThrow(
+        'GMAIL_APP_PASSWORD environment variable is required but not set',
+      );
+    });
+
+    it('should mention App Password instructions in GMAIL_APP_PASSWORD error', () => {
+      process.env['GMAIL_USER'] = 'biblioteca@gmail.com';
+      delete process.env['GMAIL_APP_PASSWORD'];
+
+      expect(() => loadEnvConfig()).toThrow(/Google App Password/);
     });
   });
 
   describe('getOllamaConfig', () => {
+    beforeEach(() => {
+      process.env['GMAIL_USER'] = 'test@gmail.com';
+      process.env['GMAIL_APP_PASSWORD'] = 'abcd efgh ijkl mnop';
+    });
+
     it('should return Ollama configuration when DATABASE_URL is set', () => {
       process.env['DATABASE_URL'] = 'postgresql://test:test@localhost:5432/testdb';
       process.env['OLLAMA_EMBEDDING_URL'] = 'http://custom:11434';

--- a/apps/api/tests/unit/infrastructure/driven/email/GmailEmailAdapter.test.ts
+++ b/apps/api/tests/unit/infrastructure/driven/email/GmailEmailAdapter.test.ts
@@ -1,0 +1,108 @@
+/**
+ * GmailEmailAdapter Unit Tests
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GmailEmailAdapter } from '../../../../../src/infrastructure/driven/email/GmailEmailAdapter.js';
+import { EmailSendError } from '../../../../../src/domain/errors/DomainErrors.js';
+
+const mockSendMail = vi.fn();
+
+vi.mock('nodemailer', () => ({
+  default: {
+    createTransport: vi.fn(() => ({
+      sendMail: mockSendMail,
+    })),
+  },
+}));
+
+import nodemailer from 'nodemailer';
+
+describe('GmailEmailAdapter', () => {
+  let adapter: GmailEmailAdapter;
+
+  const config = {
+    user: 'sender@gmail.com',
+    appPassword: 'app-secret-password',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new GmailEmailAdapter(config);
+  });
+
+  describe('constructor', () => {
+    it('should create nodemailer transporter with gmail service and provided credentials', () => {
+      expect(nodemailer.createTransport).toHaveBeenCalledWith({
+        service: 'gmail',
+        auth: {
+          user: config.user,
+          pass: config.appPassword,
+        },
+      });
+    });
+  });
+
+  describe('sendWithAttachment', () => {
+    const emailOptions = {
+      to: 'recipient@example.com',
+      subject: 'Your book',
+      body: 'Please find the attached book.',
+      attachmentPath: '/books/clean-code.epub',
+      attachmentFilename: 'clean-code.epub',
+    };
+
+    it('should call sendMail with the correct parameters', async () => {
+      mockSendMail.mockResolvedValueOnce({ messageId: 'msg-123' });
+
+      await adapter.sendWithAttachment(emailOptions);
+
+      expect(mockSendMail).toHaveBeenCalledWith({
+        from: config.user,
+        to: emailOptions.to,
+        subject: emailOptions.subject,
+        text: emailOptions.body,
+        attachments: [
+          {
+            filename: emailOptions.attachmentFilename,
+            path: emailOptions.attachmentPath,
+          },
+        ],
+      });
+    });
+
+    it('should resolve without error when sendMail succeeds', async () => {
+      mockSendMail.mockResolvedValueOnce({ messageId: 'msg-123' });
+
+      await expect(adapter.sendWithAttachment(emailOptions)).resolves.toBeUndefined();
+    });
+
+    it('should throw EmailSendError when nodemailer fails', async () => {
+      const nodemailerError = new Error('Invalid login: 535 credentials rejected');
+      mockSendMail.mockRejectedValueOnce(nodemailerError);
+
+      await expect(adapter.sendWithAttachment(emailOptions)).rejects.toThrow(EmailSendError);
+    });
+
+    it('should include the recipient in EmailSendError', async () => {
+      mockSendMail.mockRejectedValueOnce(new Error('Connection refused'));
+
+      await expect(adapter.sendWithAttachment(emailOptions)).rejects.toThrow(
+        `Failed to send email to "${emailOptions.to}"`,
+      );
+    });
+
+    it('should include the original error message as reason in EmailSendError', async () => {
+      const nodemailerError = new Error('ECONNREFUSED');
+      mockSendMail.mockRejectedValueOnce(nodemailerError);
+
+      await expect(adapter.sendWithAttachment(emailOptions)).rejects.toThrow('ECONNREFUSED');
+    });
+
+    it('should throw EmailSendError even when nodemailer throws a non-Error value', async () => {
+      mockSendMail.mockRejectedValueOnce('string error');
+
+      await expect(adapter.sendWithAttachment(emailOptions)).rejects.toThrow(EmailSendError);
+    });
+  });
+});

--- a/apps/api/tests/unit/infrastructure/driven/filesystem/NodeFileSystemAdapter.test.ts
+++ b/apps/api/tests/unit/infrastructure/driven/filesystem/NodeFileSystemAdapter.test.ts
@@ -1,0 +1,54 @@
+/**
+ * NodeFileSystemAdapter Unit Tests
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { NodeFileSystemAdapter } from '../../../../../src/infrastructure/driven/filesystem/NodeFileSystemAdapter.js';
+
+vi.mock('node:fs/promises', () => ({
+  access: vi.fn(),
+}));
+
+import { access } from 'node:fs/promises';
+
+const mockAccess = vi.mocked(access);
+
+describe('NodeFileSystemAdapter', () => {
+  let adapter: NodeFileSystemAdapter;
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  beforeEach(() => {
+    adapter = new NodeFileSystemAdapter();
+  });
+
+  describe('fileExists', () => {
+    it('should return true when file exists', async () => {
+      mockAccess.mockResolvedValueOnce(undefined);
+
+      const result = await adapter.fileExists('/some/path/book.epub');
+
+      expect(result).toBe(true);
+      expect(mockAccess).toHaveBeenCalledWith('/some/path/book.epub');
+    });
+
+    it('should return false when file does not exist', async () => {
+      mockAccess.mockRejectedValueOnce(new Error('ENOENT: no such file or directory'));
+
+      const result = await adapter.fileExists('/some/path/nonexistent.epub');
+
+      expect(result).toBe(false);
+      expect(mockAccess).toHaveBeenCalledWith('/some/path/nonexistent.epub');
+    });
+
+    it('should return false when access is denied', async () => {
+      mockAccess.mockRejectedValueOnce(new Error('EACCES: permission denied'));
+
+      const result = await adapter.fileExists('/protected/file.epub');
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/apps/api/tests/unit/infrastructure/driver/http/controllers/SendBookByEmailController.test.ts
+++ b/apps/api/tests/unit/infrastructure/driver/http/controllers/SendBookByEmailController.test.ts
@@ -1,0 +1,242 @@
+/**
+ * SendBookByEmailController Unit Tests
+ *
+ * Tests the HTTP controller for the POST /api/books/:id/send endpoint in isolation.
+ * Validates request parsing, response formatting, and error handling.
+ *
+ * HU-036: Send book by email feature.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import { SendBookByEmailController } from '../../../../../../src/infrastructure/driver/http/controllers/SendBookByEmailController.js';
+import type { SendBookByEmailUseCase } from '../../../../../../src/application/use-cases/SendBookByEmailUseCase.js';
+import { InvalidEmailAddressError } from '../../../../../../src/domain/value-objects/EmailAddress.js';
+import {
+  BookNotFoundError,
+  BookFileNotFoundError,
+  EmailSendError,
+} from '../../../../../../src/domain/errors/DomainErrors.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockUseCase(): SendBookByEmailUseCase {
+  return {
+    execute: vi.fn(),
+  } as unknown as SendBookByEmailUseCase;
+}
+
+function createMockRequest(
+  params: { id: string },
+  body: unknown,
+): FastifyRequest<{ Params: { id: string } }> {
+  return {
+    params,
+    body,
+  } as FastifyRequest<{ Params: { id: string } }>;
+}
+
+function createMockReply(): FastifyReply {
+  return {
+    status: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis(),
+  } as unknown as FastifyReply;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SendBookByEmailController', () => {
+  let controller: SendBookByEmailController;
+  let mockUseCase: SendBookByEmailUseCase;
+
+  beforeEach(() => {
+    mockUseCase = createMockUseCase();
+    controller = new SendBookByEmailController({ sendBookByEmailUseCase: mockUseCase });
+  });
+
+  describe('send', () => {
+    describe('successful request (200)', () => {
+      it('should return 200 with sent: true when email is sent successfully', async () => {
+        vi.mocked(mockUseCase.execute).mockResolvedValue(undefined);
+        const request = createMockRequest({ id: 'book-uuid-123' }, { email: 'user@example.com' });
+        const reply = createMockReply();
+
+        await controller.send(request, reply);
+
+        expect(reply.status).toHaveBeenCalledWith(200);
+        expect(reply.send).toHaveBeenCalledWith({
+          success: true,
+          data: { sent: true },
+          error: null,
+        });
+      });
+
+      it('should call the use case with the correct bookId and email', async () => {
+        vi.mocked(mockUseCase.execute).mockResolvedValue(undefined);
+        const request = createMockRequest({ id: 'book-uuid-456' }, { email: 'reader@library.com' });
+        const reply = createMockReply();
+
+        await controller.send(request, reply);
+
+        expect(mockUseCase.execute).toHaveBeenCalledWith({
+          bookId: 'book-uuid-456',
+          email: 'reader@library.com',
+        });
+      });
+    });
+
+    describe('validation errors (400)', () => {
+      it('should return 400 when email field is missing from body', async () => {
+        const request = createMockRequest({ id: 'book-uuid-123' }, {});
+        const reply = createMockReply();
+
+        await controller.send(request, reply);
+
+        expect(reply.status).toHaveBeenCalledWith(400);
+        const sentResponse = vi.mocked(reply.send).mock.calls[0][0] as {
+          success: boolean;
+          error: { message: string };
+        };
+        expect(sentResponse.success).toBe(false);
+        expect(sentResponse.error.message).toBe('Validation failed');
+        expect(mockUseCase.execute).not.toHaveBeenCalled();
+      });
+
+      it('should return 400 when email has invalid format', async () => {
+        const request = createMockRequest({ id: 'book-uuid-123' }, { email: 'not-an-email' });
+        const reply = createMockReply();
+
+        await controller.send(request, reply);
+
+        expect(reply.status).toHaveBeenCalledWith(400);
+        const sentResponse = vi.mocked(reply.send).mock.calls[0][0] as {
+          success: boolean;
+        };
+        expect(sentResponse.success).toBe(false);
+        expect(mockUseCase.execute).not.toHaveBeenCalled();
+      });
+
+      it('should return 400 when use case throws InvalidEmailAddressError', async () => {
+        vi.mocked(mockUseCase.execute).mockRejectedValue(
+          new InvalidEmailAddressError('bad-email'),
+        );
+        // Bypass Zod validation with a technically valid-looking email that fails VO
+        const request = createMockRequest({ id: 'book-uuid-123' }, { email: 'bad@email.com' });
+        const reply = createMockReply();
+
+        await controller.send(request, reply);
+
+        expect(reply.status).toHaveBeenCalledWith(400);
+        const sentResponse = vi.mocked(reply.send).mock.calls[0][0] as {
+          success: boolean;
+          error: { message: string };
+        };
+        expect(sentResponse.success).toBe(false);
+        expect(sentResponse.error.message).toContain('bad-email');
+      });
+
+      it('should return 400 when email field is null', async () => {
+        const request = createMockRequest({ id: 'book-uuid-123' }, { email: null });
+        const reply = createMockReply();
+
+        await controller.send(request, reply);
+
+        expect(reply.status).toHaveBeenCalledWith(400);
+      });
+    });
+
+    describe('not found errors (404)', () => {
+      it('should return 404 when use case throws BookNotFoundError', async () => {
+        vi.mocked(mockUseCase.execute).mockRejectedValue(
+          new BookNotFoundError('missing-book-id'),
+        );
+        const request = createMockRequest({ id: 'missing-book-id' }, { email: 'user@example.com' });
+        const reply = createMockReply();
+
+        await controller.send(request, reply);
+
+        expect(reply.status).toHaveBeenCalledWith(404);
+        const sentResponse = vi.mocked(reply.send).mock.calls[0][0] as {
+          success: boolean;
+          error: { message: string };
+        };
+        expect(sentResponse.success).toBe(false);
+        expect(sentResponse.error.message).toContain('missing-book-id');
+      });
+    });
+
+    describe('unprocessable entity errors (422)', () => {
+      it('should return 422 when use case throws BookFileNotFoundError', async () => {
+        vi.mocked(mockUseCase.execute).mockRejectedValue(
+          new BookFileNotFoundError('book-uuid-123'),
+        );
+        const request = createMockRequest({ id: 'book-uuid-123' }, { email: 'user@example.com' });
+        const reply = createMockReply();
+
+        await controller.send(request, reply);
+
+        expect(reply.status).toHaveBeenCalledWith(422);
+        const sentResponse = vi.mocked(reply.send).mock.calls[0][0] as {
+          success: boolean;
+          error: { message: string };
+        };
+        expect(sentResponse.success).toBe(false);
+        expect(sentResponse.error.message).toContain('book-uuid-123');
+      });
+    });
+
+    describe('email send errors (500)', () => {
+      it('should return 500 when use case throws EmailSendError', async () => {
+        vi.mocked(mockUseCase.execute).mockRejectedValue(
+          new EmailSendError('user@example.com', 'SMTP timeout'),
+        );
+        const request = createMockRequest({ id: 'book-uuid-123' }, { email: 'user@example.com' });
+        const reply = createMockReply();
+
+        await controller.send(request, reply);
+
+        expect(reply.status).toHaveBeenCalledWith(500);
+        const sentResponse = vi.mocked(reply.send).mock.calls[0][0] as {
+          success: boolean;
+          error: { message: string };
+        };
+        expect(sentResponse.success).toBe(false);
+        expect(sentResponse.error.message).toContain('user@example.com');
+      });
+
+      it('should return 500 for unexpected errors', async () => {
+        vi.mocked(mockUseCase.execute).mockRejectedValue(new Error('Unexpected DB failure'));
+        const request = createMockRequest({ id: 'book-uuid-123' }, { email: 'user@example.com' });
+        const reply = createMockReply();
+
+        await controller.send(request, reply);
+
+        expect(reply.status).toHaveBeenCalledWith(500);
+        const sentResponse = vi.mocked(reply.send).mock.calls[0][0] as {
+          success: boolean;
+          error: { message: string };
+        };
+        expect(sentResponse.success).toBe(false);
+        expect(sentResponse.error.message).toBe('Unexpected DB failure');
+      });
+
+      it('should return 500 for non-Error thrown values', async () => {
+        vi.mocked(mockUseCase.execute).mockRejectedValue('string error');
+        const request = createMockRequest({ id: 'book-uuid-123' }, { email: 'user@example.com' });
+        const reply = createMockReply();
+
+        await controller.send(request, reply);
+
+        expect(reply.status).toHaveBeenCalledWith(500);
+        const sentResponse = vi.mocked(reply.send).mock.calls[0][0] as {
+          success: boolean;
+        };
+        expect(sentResponse.success).toBe(false);
+      });
+    });
+  });
+});

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -62,6 +62,8 @@ services:
     volumes:
       # Mount initial_data directory for seeding (run: docker exec library-api npm run seed:prod)
       - ./initial_data:/app/data/initial_data:ro
+      # Books directory (read-only mount for email delivery)
+      - ${BOOKS_PATH}:/books:ro
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       - ./apps/api/drizzle:/app/drizzle
       # Docs directory for consolidated output
       - ./docs:/app/docs
+      # Books directory (read-only mount for email delivery)
+      - ${BOOKS_PATH}:/books:ro
       # Original data directory (source JSON files for consolidation)
       - ./original_data:/app/original_data
       # Named volume for node_modules (prevents overwrite by host)

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -547,6 +547,133 @@ paths:
                     error:
                       message: "Translation service unavailable, please try again later"
 
+  /books/{id}/send:
+    post:
+      tags:
+        - Books
+      summary: Send book file by email
+      description: |
+        Envía el archivo físico del libro al correo electrónico indicado.
+
+        ## Flujo
+
+        1. **Validación**: Se valida que el `email` tenga formato válido
+        2. **Búsqueda**: Se recupera el libro por `id` — si no existe, se retorna `404`
+        3. **Verificación de archivo**: Se comprueba que el libro tenga un `path` asignado y que
+           el archivo físico exista en disco — si no, se retorna `422`
+        4. **Envío**: Se envía el archivo adjunto al correo indicado — si el servicio de correo
+           falla, se retorna `500`
+
+        ## Notas
+
+        - El correo se envía con el archivo adjunto (no como enlace)
+        - No se requiere autenticación para este endpoint (según configuración del servidor)
+      operationId: sendBookByEmail
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Identificador único del libro (UUID v4)
+          schema:
+            type: string
+            format: uuid
+            example: "550e8400-e29b-41d4-a716-446655440000"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SendBookRequest'
+            example:
+              email: "usuario@example.com"
+      responses:
+        '200':
+          description: Correo enviado exitosamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiSuccessResponse'
+              example:
+                success: true
+                data: null
+                error: null
+        '400':
+          description: |
+            Solicitud inválida. Posibles causas:
+            - El campo `email` no tiene un formato de correo electrónico válido
+            - El campo `email` está vacío o ausente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                invalid_email_format:
+                  summary: Formato de email inválido
+                  value:
+                    success: false
+                    data: null
+                    error:
+                      message: "Validation failed"
+                      details:
+                        - "email: Invalid email"
+                missing_email:
+                  summary: Email ausente
+                  value:
+                    success: false
+                    data: null
+                    error:
+                      message: "Validation failed"
+                      details:
+                        - "email is required"
+        '404':
+          description: Libro no encontrado. No existe ningún libro con el `id` indicado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              example:
+                success: false
+                data: null
+                error:
+                  message: "Book with id \"550e8400-e29b-41d4-a716-446655440000\" not found"
+        '422':
+          description: |
+            Entidad no procesable. Posibles causas:
+            - El libro no tiene un `path` asignado en la base de datos
+            - El archivo físico referenciado por `path` no existe en el sistema de archivos
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                no_path_assigned:
+                  summary: Libro sin path asignado
+                  value:
+                    success: false
+                    data: null
+                    error:
+                      message: "Book file not found for book \"550e8400-e29b-41d4-a716-446655440000\""
+                file_not_on_disk:
+                  summary: Archivo no encontrado en disco
+                  value:
+                    success: false
+                    data: null
+                    error:
+                      message: "Book file not found for book \"550e8400-e29b-41d4-a716-446655440000\""
+        '500':
+          description: |
+            Error interno del servidor al intentar enviar el correo.
+            El archivo existe pero el servicio de correo falló.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              example:
+                success: false
+                data: null
+                error:
+                  message: "Failed to send email"
+
   /book-types:
     get:
       tags:
@@ -1296,6 +1423,21 @@ components:
           description: Lista de libros que coinciden con los criterios de búsqueda
         pagination:
           $ref: '#/components/schemas/BookSearchPagination'
+
+    # ============================================
+    # HU-036: Send Book by Email Schemas
+    # ============================================
+
+    SendBookRequest:
+      type: object
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          format: email
+          description: Dirección de correo electrónico a la que se enviará el archivo del libro
+          example: "usuario@example.com"
 
     BookSearchResponse:
       allOf:

--- a/docs/user_stories/33-hu-036-send-book-by-email.md
+++ b/docs/user_stories/33-hu-036-send-book-by-email.md
@@ -1,0 +1,174 @@
+# HU-036: Envío de libro por email
+
+## Descripción
+
+**Como** usuario de la biblioteca digital,  
+**Quiero** poder enviar el archivo de un libro a una dirección de email,  
+**Para** poder leerlo en cualquier dispositivo o cliente de lectura (p. ej. Kindle via email).
+
+---
+
+## Contexto y motivación
+
+La tabla `books` dispone de una columna `path` que almacena la ruta física del archivo asociado a cada libro. Actualmente ese dato existe en base de datos pero no se expone mediante ninguna acción útil al usuario.
+
+Esta historia implementa el endpoint `POST /books/:id/send` que, dado el ID de un libro y una dirección de email destino, adjunta el archivo del libro en un correo y lo envía usando la cuenta Gmail preconfigurada en la API.
+
+Para que esto sea posible se requieren dos cambios de infraestructura:
+
+1. **Volumen físico**: el contenedor de la API necesita acceso al directorio del host donde residen los archivos de los libros. Esto se configura mediante un `bind mount` en el `docker-compose` de desarrollo y producción.
+2. **Servicio de correo**: la API necesita credenciales de Gmail (usuario + contraseña de aplicación) inyectadas como variables de entorno.
+
+---
+
+## Criterios de Aceptación
+
+### CA-1: Endpoint disponible
+- Existe el endpoint `POST /api/books/:id/send`.
+- Acepta un body JSON con el campo `email` (string, formato email válido).
+- Devuelve `200 OK` cuando el correo se ha enviado correctamente (flujo sincrónico).
+
+### CA-2: Validaciones de negocio
+- Si el libro no existe → `404 Not Found` con mensaje descriptivo.
+- Si el libro no tiene `path` definido (null o vacío) → `422 Unprocessable Entity` indicando que el libro no tiene archivo asociado.
+- Si el archivo físico no existe en la ruta indicada por `path` → `422 Unprocessable Entity` indicando que el archivo no está disponible.
+- Si el `email` recibido no es válido → `400 Bad Request` con detalle de validación Zod.
+
+### CA-3: Envío del correo
+- El correo se envía desde la cuenta Gmail configurada en las variables de entorno (`GMAIL_USER`, `GMAIL_APP_PASSWORD`).
+- El correo incluye el archivo del libro como adjunto.
+- El asunto del correo sigue el patrón: `[Library] {título del libro}`.
+- El cuerpo del correo incluye el título y el autor del libro.
+
+### CA-4: Infraestructura — volumen de libros
+- El `docker-compose.dev.yml` monta un volumen tipo `bind mount` desde la variable de entorno `BOOKS_PATH` del host hacia `/books` dentro del contenedor.
+- El `docker-compose.prod.yml` aplica el mismo bind mount.
+- La variable `BOOKS_PATH` se documenta en el `.env.example` de la API.
+
+### CA-5: Infraestructura — credenciales Gmail
+- Las variables `GMAIL_USER` y `GMAIL_APP_PASSWORD` se añaden al `.env.example` de la API.
+- La aplicación falla al arrancar con un error descriptivo si alguna de estas variables no está definida (fail-fast).
+
+### CA-6: Documentación OpenAPI
+- El endpoint `POST /api/books/:id/send` está documentado en el fichero OpenAPI existente (`docs/api/`).
+- Se documentan los esquemas de request body, respuestas `200`, `400`, `404` y `422`.
+
+### CA-7: Tests
+- Tests unitarios para la lógica de dominio / casos de error (libro no encontrado, sin path, archivo inexistente, email inválido).
+- Tests de integración que verifiquen el flujo completo con un mock del servicio de email (no se envían emails reales en tests).
+- Cobertura mínima del 80% en el código nuevo.
+
+---
+
+## Diseño técnico de alto nivel
+
+### Nuevo endpoint
+
+```
+POST /api/books/:id/send
+Content-Type: application/json
+
+{ "email": "usuario@example.com" }
+```
+
+### Flujo interno (Hexagonal Architecture)
+
+```
+HTTP Route (Fastify)
+  → SendBookByEmailUseCase
+      → BookRepository.findById()        [Port]
+      → FileSystemPort.fileExists()      [Port]
+      → EmailPort.sendWithAttachment()   [Port]
+```
+
+### Nuevos puertos (interfaces de dominio)
+- `EmailPort` — `sendWithAttachment(to, subject, body, filePath): Promise<void>`
+- `FileSystemPort` — `fileExists(path: string): Promise<boolean>`
+
+### Nuevos adaptadores de infraestructura
+- `GmailEmailAdapter` — implementa `EmailPort` usando `nodemailer` con transporte Gmail.
+- `NodeFileSystemAdapter` — implementa `FileSystemPort` usando `fs/promises`.
+
+### Variables de entorno nuevas
+
+| Variable | Descripción | Ejemplo |
+|---|---|---|
+| `GMAIL_USER` | Cuenta Gmail remitente | `biblioteca@gmail.com` |
+| `GMAIL_APP_PASSWORD` | Contraseña de aplicación de Google | `abcd efgh ijkl mnop` |
+| `BOOKS_PATH` | Ruta absoluta en el host donde residen los archivos | `/home/user/books` |
+
+---
+
+## Tareas técnicas
+
+### Tarea 1 — Infraestructura: volumen de libros y variables de entorno
+**Branch**: `task/HU-036-01-infra-volumes-and-env`
+
+- [ ] Añadir bind mount en `docker/docker-compose.dev.yml`: `${BOOKS_PATH}:/books:ro`.
+- [ ] Añadir bind mount en `docker/docker-compose.prod.yml`: `${BOOKS_PATH}:/books:ro`.
+- [ ] Añadir `BOOKS_PATH`, `GMAIL_USER`, `GMAIL_APP_PASSWORD` al `apps/api/.env.example` con comentarios descriptivos.
+- [ ] Añadir validación fail-fast en el arranque de la API para `GMAIL_USER` y `GMAIL_APP_PASSWORD`.
+
+### Tarea 2 — Dominio: Value Object `EmailAddress` y errores de dominio
+**Branch**: `task/HU-036-02-domain-email-vo-and-errors`
+
+- [ ] Crear Value Object `EmailAddress` en `src/domain/shared/value-objects/EmailAddress.ts` con validación de formato.
+- [ ] Crear errores de dominio específicos:
+  - `BookFileNotFoundError` — libro sin `path` o archivo físico inexistente.
+  - `EmailSendError` — fallo al enviar el correo.
+- [ ] Tests unitarios para `EmailAddress` y los nuevos errores.
+
+### Tarea 3 — Dominio: puertos `EmailPort` y `FileSystemPort`
+**Branch**: `task/HU-036-03-domain-ports`
+
+- [ ] Definir interfaz `EmailPort` en `src/domain/ports/EmailPort.ts`.
+- [ ] Definir interfaz `FileSystemPort` en `src/domain/ports/FileSystemPort.ts`.
+- [ ] Tests unitarios con mocks de ambos puertos.
+
+### Tarea 4 — Caso de uso: `SendBookByEmailUseCase`
+**Branch**: `task/HU-036-04-use-case`
+
+- [ ] Implementar `SendBookByEmailUseCase` en `src/application/use-cases/SendBookByEmailUseCase.ts`.
+- [ ] Orquesta: buscar libro → verificar path → verificar archivo → enviar email.
+- [ ] Tests unitarios cubriendo todos los casos de error de CA-2 y el caso feliz.
+
+### Tarea 5 — Infraestructura: adaptadores `GmailEmailAdapter` y `NodeFileSystemAdapter`
+**Branch**: `task/HU-036-05-adapters`
+
+- [ ] Instalar dependencia `nodemailer` y sus tipos (`@types/nodemailer`).
+- [ ] Implementar `GmailEmailAdapter` en `src/infrastructure/email/GmailEmailAdapter.ts`.
+- [ ] Implementar `NodeFileSystemAdapter` en `src/infrastructure/filesystem/NodeFileSystemAdapter.ts`.
+- [ ] Tests de integración del adaptador de email con un mock del transporte `nodemailer`.
+
+### Tarea 6 — HTTP: ruta `POST /api/books/:id/send`
+**Branch**: `task/HU-036-06-http-route`
+
+- [ ] Crear el schema Zod para el body `{ email: string }`.
+- [ ] Registrar la ruta en Fastify con validación de schema.
+- [ ] Mapear errores de dominio a códigos HTTP (`404`, `422`).
+- [ ] Tests E2E del endpoint cubriendo todos los casos de CA-1 y CA-2 (`200` en el happy path).
+
+### Tarea 7 — Documentación OpenAPI
+**Branch**: `task/HU-036-07-openapi-docs`
+
+- [ ] Documentar `POST /api/books/{id}/send` en el fichero OpenAPI de `docs/api/`.
+- [ ] Incluir esquemas de request body, y respuestas `200`, `400`, `404`, `422`.
+
+---
+
+## Dependencias externas
+
+| Dependencia | Motivo |
+|---|---|
+| `nodemailer` | Envío de email con adjunto via Gmail SMTP |
+| Cuenta Gmail con contraseña de aplicación habilitada | Autenticación SMTP con 2FA activo |
+
+---
+
+## Riesgos
+
+| Riesgo | Mitigación |
+|---|---|
+| Gmail puede bloquear el envío si la contraseña de app no está bien configurada | Documentar el proceso de creación de contraseña de app en el `.env.example` |
+| El archivo del libro puede ser muy grande para adjuntar por email | Aceptado en MVP; se puede añadir límite de tamaño en futuras HUs |
+| El path del libro en DB es relativo al mount point `/books` del contenedor | El path en DB se concatena como `/books/{path}` dentro del contenedor; documentar esta convención en el `.env.example` |


### PR DESCRIPTION
## Descripción

Implementa el endpoint `POST /api/books/:id/send` que adjunta el archivo de un libro y lo envía por email usando Gmail SMTP.

## Cambios incluidos

### Infraestructura
- Bind mount `${BOOKS_PATH}:/books:ro` en `docker-compose.yml` y `docker-compose.prod.yml`
- Variables de entorno nuevas: `GMAIL_USER`, `GMAIL_APP_PASSWORD`, `BOOKS_PATH` en `.env.example`
- Validación fail-fast al arranque para credenciales Gmail

### Dominio
- Value Object `EmailAddress` con validación de formato
- Errores de dominio: `BookFileNotFoundError`, `EmailSendError`
- Puertos: `EmailPort`, `FileSystemPort`

### Aplicación
- `SendBookByEmailUseCase` con flujo completo: buscar libro → verificar path → verificar archivo → enviar email

### Infraestructura (adaptadores)
- `GmailEmailAdapter` usando `nodemailer` + Gmail SMTP
- `NodeFileSystemAdapter` usando `node:fs/promises`

### HTTP
- Ruta `POST /api/books/:id/send` con validación Zod
- Mapeo de errores: 400 / 404 / 422 / 500
- Documentación OpenAPI actualizada

## Tests
- 1504 tests unitarios — todos verdes ✅
- ESLint: 0 errores, 0 warnings ✅
- Cobertura nuevos archivos: 100% use case, 100% EmailAddress VO

## Issue
Cierra #408