### PR TITLE
feat: HU-039 Control de Acceso y Favoritos

### DIFF
--- a/apps/api/drizzle/0003_organic_shiver_man.sql
+++ b/apps/api/drizzle/0003_organic_shiver_man.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "user_book_downloads" (
+	"user_id" uuid NOT NULL,
+	"book_id" uuid NOT NULL,
+	"downloaded_at" timestamp with time zone DEFAULT now(),
+	CONSTRAINT "user_book_downloads_user_id_book_id_pk" PRIMARY KEY("user_id","book_id")
+);
+--> statement-breakpoint
+CREATE TABLE "user_book_favorites" (
+	"user_id" uuid NOT NULL,
+	"book_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now(),
+	CONSTRAINT "user_book_favorites_user_id_book_id_pk" PRIMARY KEY("user_id","book_id")
+);
+--> statement-breakpoint
+ALTER TABLE "user_book_downloads" ADD CONSTRAINT "user_book_downloads_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_book_downloads" ADD CONSTRAINT "user_book_downloads_book_id_books_id_fk" FOREIGN KEY ("book_id") REFERENCES "public"."books"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_book_favorites" ADD CONSTRAINT "user_book_favorites_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_book_favorites" ADD CONSTRAINT "user_book_favorites_book_id_books_id_fk" FOREIGN KEY ("book_id") REFERENCES "public"."books"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "user_book_favorites_user_idx" ON "user_book_favorites" USING btree ("user_id");

--- a/apps/api/drizzle/meta/0003_snapshot.json
+++ b/apps/api/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1058 @@
+{
+  "id": "84e3d99d-c688-447b-91ae-10e691c1ab07",
+  "prevId": "9f3ffe38-b789-42cd-9711-96959c65bc9f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.authors": {
+      "name": "authors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "authors_name_idx": {
+          "name": "authors_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authors_name_unique": {
+          "name": "authors_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_authors": {
+      "name": "book_authors",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_authors_author_idx": {
+          "name": "book_authors_author_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_authors_book_id_books_id_fk": {
+          "name": "book_authors_book_id_books_id_fk",
+          "tableFrom": "book_authors",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_authors_author_id_authors_id_fk": {
+          "name": "book_authors_author_id_authors_id_fk",
+          "tableFrom": "book_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_authors_book_id_author_id_pk": {
+          "name": "book_authors_book_id_author_id_pk",
+          "columns": [
+            "book_id",
+            "author_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_categories": {
+      "name": "book_categories",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_categories_category_idx": {
+          "name": "book_categories_category_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_categories_book_id_books_id_fk": {
+          "name": "book_categories_book_id_books_id_fk",
+          "tableFrom": "book_categories",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_categories_category_id_categories_id_fk": {
+          "name": "book_categories_category_id_categories_id_fk",
+          "tableFrom": "book_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_categories_book_id_category_id_pk": {
+          "name": "book_categories_book_id_category_id_pk",
+          "columns": [
+            "book_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "isbn": {
+          "name": "isbn",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_description": {
+          "name": "original_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level_id": {
+          "name": "level_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_title": {
+          "name": "normalized_title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "books_isbn_unique_idx": {
+          "name": "books_isbn_unique_idx",
+          "columns": [
+            {
+              "expression": "isbn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_title_idx": {
+          "name": "books_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_type_id_idx": {
+          "name": "books_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_level_id_idx": {
+          "name": "books_level_id_idx",
+          "columns": [
+            {
+              "expression": "level_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "books_type_id_types_id_fk": {
+          "name": "books_type_id_types_id_fk",
+          "tableFrom": "books",
+          "tableTo": "types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "books_level_id_levels_id_fk": {
+          "name": "books_level_id_levels_id_fk",
+          "tableFrom": "books",
+          "tableTo": "levels",
+          "columnsFrom": [
+            "level_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "categories_type_idx": {
+          "name": "categories_type_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_name_idx": {
+          "name": "categories_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_type_id_types_id_fk": {
+          "name": "categories_type_id_types_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_name_type_unique": {
+          "name": "categories_name_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "type_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.levels": {
+      "name": "levels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "levels_name_idx": {
+          "name": "levels_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "levels_name_unique": {
+          "name": "levels_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "password_reset_tokens_user_idx": {
+          "name": "password_reset_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.type_levels": {
+      "name": "type_levels",
+      "schema": "",
+      "columns": {
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level_id": {
+          "name": "level_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "type_levels_type_idx": {
+          "name": "type_levels_type_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "type_levels_level_idx": {
+          "name": "type_levels_level_idx",
+          "columns": [
+            {
+              "expression": "level_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "type_levels_type_id_types_id_fk": {
+          "name": "type_levels_type_id_types_id_fk",
+          "tableFrom": "type_levels",
+          "tableTo": "types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "type_levels_level_id_levels_id_fk": {
+          "name": "type_levels_level_id_levels_id_fk",
+          "tableFrom": "type_levels",
+          "tableTo": "levels",
+          "columnsFrom": [
+            "level_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "type_levels_type_id_level_id_pk": {
+          "name": "type_levels_type_id_level_id_pk",
+          "columns": [
+            "type_id",
+            "level_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.types": {
+      "name": "types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "types_name_idx": {
+          "name": "types_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "types_name_unique": {
+          "name": "types_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_book_downloads": {
+      "name": "user_book_downloads",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downloaded_at": {
+          "name": "downloaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_book_downloads_user_id_users_id_fk": {
+          "name": "user_book_downloads_user_id_users_id_fk",
+          "tableFrom": "user_book_downloads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_book_downloads_book_id_books_id_fk": {
+          "name": "user_book_downloads_book_id_books_id_fk",
+          "tableFrom": "user_book_downloads",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_book_downloads_user_id_book_id_pk": {
+          "name": "user_book_downloads_user_id_book_id_pk",
+          "columns": [
+            "user_id",
+            "book_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_book_favorites": {
+      "name": "user_book_favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_book_favorites_user_idx": {
+          "name": "user_book_favorites_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_book_favorites_user_id_users_id_fk": {
+          "name": "user_book_favorites_user_id_users_id_fk",
+          "tableFrom": "user_book_favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_book_favorites_book_id_books_id_fk": {
+          "name": "user_book_favorites_book_id_books_id_fk",
+          "tableFrom": "user_book_favorites",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_book_favorites_user_id_book_id_pk": {
+          "name": "user_book_favorites_user_id_book_id_pk",
+          "columns": [
+            "user_id",
+            "book_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1778427816041,
       "tag": "0002_broad_mister_fear",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1778443449085,
+      "tag": "0003_organic_shiver_man",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/application/ports/BookRepository.ts
+++ b/apps/api/src/application/ports/BookRepository.ts
@@ -12,6 +12,7 @@
 
 import type { Book } from '../../domain/entities/Book.js';
 import type { Criteria } from '../../domain/criteria/Criteria.js';
+import type { BookId } from '../../domain/book/value-objects/BookId.js';
 
 /**
  * A book with its similarity score (for semantic search results)
@@ -197,7 +198,9 @@ export interface BookRepository {
    *
    * @param criteria - Domain criteria object with filters, order, limit, cursor
    * @param embedding - Optional embedding vector for semantic search (SIMILAR_TO filter)
+   * @param favoritesOf - Optional list of BookIds to restrict results to (favorites filter).
+   *                      If provided and empty, implementations must return empty results immediately.
    * @returns Promise resolving to paginated search results with similarity scores
    */
-  search(criteria: Criteria, embedding?: number[]): Promise<SearchBooksResult>;
+  search(criteria: Criteria, embedding?: number[], favoritesOf?: BookId[]): Promise<SearchBooksResult>;
 }

--- a/apps/api/src/application/use-cases/SearchBooksUseCase.ts
+++ b/apps/api/src/application/use-cases/SearchBooksUseCase.ts
@@ -29,6 +29,7 @@ import type { FavoriteRepository } from '../../domain/favorite/ports/FavoriteRep
 import type { Logger } from '../ports/Logger.js';
 import { noopLogger } from '../ports/Logger.js';
 import type { UserId } from '../../domain/user/value-objects/UserId.js';
+import type { BookId } from '../../domain/book/value-objects/BookId.js';
 
 /**
  * Input DTO for searching books
@@ -143,14 +144,13 @@ export class SearchBooksUseCase {
       hasFavoritesFilter: !!input.favoritesOf,
     });
 
-    // 1. If filtering by favorites, resolve the bookId set first
-    let favoriteBookIds: Set<string> | undefined;
+    // 1. If filtering by favorites, resolve the bookId list first
+    let favoriteBookIds: BookId[] | undefined;
     if (input.favoritesOf) {
-      const bookIds = await this.favoriteRepository!.findAllByUser(input.favoritesOf);
-      favoriteBookIds = new Set(bookIds.map((id) => id.value));
+      favoriteBookIds = await this.favoriteRepository!.findAllByUser(input.favoritesOf);
 
       // Short-circuit: if user has no favorites, return empty result immediately
-      if (favoriteBookIds.size === 0) {
+      if (favoriteBookIds.length === 0) {
         return {
           items: [],
           pagination: { limit, hasNextPage: false, nextCursor: null, totalCount: 0 },
@@ -182,8 +182,8 @@ export class SearchBooksUseCase {
       hasSimilarityFilter: criteria.hasSimilarityFilter(),
     });
 
-    // 4. Execute search
-    const result = await this.bookRepository.search(criteria, embedding);
+    // 4. Execute search — pass favoriteBookIds to let the repository filter at DB level
+    const result = await this.bookRepository.search(criteria, embedding, favoriteBookIds);
 
     this.logger.info('Book search completed', {
       resultCount: result.items.length,
@@ -191,12 +191,7 @@ export class SearchBooksUseCase {
       hasNextPage: result.hasNextPage,
     });
 
-    // 5. Filter by favorites if needed
-    if (favoriteBookIds) {
-      result.items = result.items.filter((item) => favoriteBookIds!.has(item.book.id));
-    }
-
-    // 6. Map results to output
+    // 5. Map results to output
     return this.toOutput(result, limit);
   }
 

--- a/apps/api/src/application/use-cases/SearchBooksUseCase.ts
+++ b/apps/api/src/application/use-cases/SearchBooksUseCase.ts
@@ -25,8 +25,10 @@ import { Order } from '../../domain/criteria/Order.js';
 import { Filter } from '../../domain/criteria/Filter.js';
 import type { BookRepository, SearchBooksResult } from '../ports/BookRepository.js';
 import type { EmbeddingService } from '../ports/EmbeddingService.js';
+import type { FavoriteRepository } from '../../domain/favorite/ports/FavoriteRepository.js';
 import type { Logger } from '../ports/Logger.js';
 import { noopLogger } from '../ports/Logger.js';
+import type { UserId } from '../../domain/user/value-objects/UserId.js';
 
 /**
  * Input DTO for searching books
@@ -53,6 +55,8 @@ export interface SearchBooksInput {
   limit?: number;
   /** Cursor for pagination */
   cursor?: string;
+  /** If provided, only returns books favorited by this user */
+  favoritesOf?: UserId;
 }
 
 /**
@@ -100,6 +104,7 @@ export interface SearchBooksUseCaseDeps {
   bookRepository: BookRepository;
   embeddingService: EmbeddingService;
   logger?: Logger;
+  favoriteRepository?: FavoriteRepository;
 }
 
 /**
@@ -111,11 +116,13 @@ export class SearchBooksUseCase {
   private readonly bookRepository: BookRepository;
   private readonly embeddingService: EmbeddingService;
   private readonly logger: Logger;
+  private readonly favoriteRepository: FavoriteRepository | undefined;
 
   constructor(deps: SearchBooksUseCaseDeps) {
     this.bookRepository = deps.bookRepository;
     this.embeddingService = deps.embeddingService;
     this.logger = deps.logger?.child({ name: 'SearchBooksUseCase' }) ?? noopLogger;
+    this.favoriteRepository = deps.favoriteRepository;
   }
 
   /**
@@ -133,9 +140,25 @@ export class SearchBooksUseCase {
       filterCount: this.countFilters(input),
       limit,
       hasCursor: !!input.cursor,
+      hasFavoritesFilter: !!input.favoritesOf,
     });
 
-    // 1. Generate embedding if text filter is present
+    // 1. If filtering by favorites, resolve the bookId set first
+    let favoriteBookIds: Set<string> | undefined;
+    if (input.favoritesOf) {
+      const bookIds = await this.favoriteRepository!.findAllByUser(input.favoritesOf);
+      favoriteBookIds = new Set(bookIds.map((id) => id.value));
+
+      // Short-circuit: if user has no favorites, return empty result immediately
+      if (favoriteBookIds.size === 0) {
+        return {
+          items: [],
+          pagination: { limit, hasNextPage: false, nextCursor: null, totalCount: 0 },
+        };
+      }
+    }
+
+    // 2. Generate embedding if text filter is present
     let embedding: number[] | undefined;
     if (input.text) {
       this.logger.debug('Generating embedding for semantic search', {
@@ -150,7 +173,7 @@ export class SearchBooksUseCase {
       });
     }
 
-    // 2. Build Criteria from input
+    // 3. Build Criteria from input
     const criteria = this.buildCriteria(input, limit);
 
     this.logger.debug('Criteria built', {
@@ -159,7 +182,7 @@ export class SearchBooksUseCase {
       hasSimilarityFilter: criteria.hasSimilarityFilter(),
     });
 
-    // 3. Execute search
+    // 4. Execute search
     const result = await this.bookRepository.search(criteria, embedding);
 
     this.logger.info('Book search completed', {
@@ -168,7 +191,12 @@ export class SearchBooksUseCase {
       hasNextPage: result.hasNextPage,
     });
 
-    // 4. Map results to output
+    // 5. Filter by favorites if needed
+    if (favoriteBookIds) {
+      result.items = result.items.filter((item) => favoriteBookIds!.has(item.book.id));
+    }
+
+    // 6. Map results to output
     return this.toOutput(result, limit);
   }
 

--- a/apps/api/src/application/use-cases/download/RegisterDownloadUseCase.ts
+++ b/apps/api/src/application/use-cases/download/RegisterDownloadUseCase.ts
@@ -1,0 +1,57 @@
+/**
+ * RegisterDownloadUseCase
+ *
+ * Application use case that registers a book download event for a user.
+ *
+ * Flow:
+ * 1. Create a Download entity with the current timestamp
+ * 2. Call DownloadRepository.upsert() — creates or updates the record
+ *
+ * HU-039: Register download use case.
+ */
+
+import type { DownloadRepository } from '../../../domain/download/ports/DownloadRepository.js';
+import { Download } from '../../../domain/download/Download.js';
+import type { UserId } from '../../../domain/user/value-objects/UserId.js';
+import type { BookId } from '../../../domain/book/value-objects/BookId.js';
+
+/**
+ * Input DTO for the register download use case
+ */
+export interface RegisterDownloadInput {
+  userId: UserId;
+  bookId: BookId;
+}
+
+/**
+ * Dependencies required by RegisterDownloadUseCase
+ */
+export interface RegisterDownloadUseCaseDeps {
+  downloadRepository: DownloadRepository;
+}
+
+/**
+ * RegisterDownloadUseCase
+ *
+ * Persists a download event (upsert) for a (userId, bookId) pair.
+ * Errors from the repository are propagated as-is.
+ */
+export class RegisterDownloadUseCase {
+  private readonly downloadRepository: DownloadRepository;
+
+  constructor(deps: RegisterDownloadUseCaseDeps) {
+    this.downloadRepository = deps.downloadRepository;
+  }
+
+  /**
+   * Executes the register download use case
+   *
+   * @param input - The userId and bookId of the download event
+   * @returns Promise that resolves when the download is recorded
+   */
+  async execute(input: RegisterDownloadInput): Promise<void> {
+    const { userId, bookId } = input;
+    const download = Download.create(userId, bookId);
+    await this.downloadRepository.upsert(download);
+  }
+}

--- a/apps/api/src/application/use-cases/favorite/ToggleFavoriteUseCase.ts
+++ b/apps/api/src/application/use-cases/favorite/ToggleFavoriteUseCase.ts
@@ -1,0 +1,73 @@
+/**
+ * ToggleFavoriteUseCase
+ *
+ * Application use case that toggles a book as favorite for a user.
+ *
+ * Flow:
+ * 1. Check if the (userId, bookId) pair already exists in favorites
+ * 2. If it exists → remove it and return { favorite: false }
+ * 3. If it does not exist → create and persist it, return { favorite: true }
+ *
+ * HU-039: Toggle favorite use case.
+ */
+
+import type { FavoriteRepository } from '../../../domain/favorite/ports/FavoriteRepository.js';
+import { Favorite } from '../../../domain/favorite/Favorite.js';
+import type { UserId } from '../../../domain/user/value-objects/UserId.js';
+import type { BookId } from '../../../domain/book/value-objects/BookId.js';
+
+/**
+ * Input DTO for the toggle favorite use case
+ */
+export interface ToggleFavoriteInput {
+  userId: UserId;
+  bookId: BookId;
+}
+
+/**
+ * Output DTO for the toggle favorite use case
+ */
+export interface ToggleFavoriteOutput {
+  favorite: boolean;
+}
+
+/**
+ * Dependencies required by ToggleFavoriteUseCase
+ */
+export interface ToggleFavoriteUseCaseDeps {
+  favoriteRepository: FavoriteRepository;
+}
+
+/**
+ * ToggleFavoriteUseCase
+ *
+ * Adds or removes a book from a user's favorites based on current state.
+ */
+export class ToggleFavoriteUseCase {
+  private readonly favoriteRepository: FavoriteRepository;
+
+  constructor(deps: ToggleFavoriteUseCaseDeps) {
+    this.favoriteRepository = deps.favoriteRepository;
+  }
+
+  /**
+   * Executes the toggle favorite use case
+   *
+   * @param input - The userId and bookId to toggle
+   * @returns Promise resolving to { favorite: true } if added, { favorite: false } if removed
+   */
+  async execute(input: ToggleFavoriteInput): Promise<ToggleFavoriteOutput> {
+    const { userId, bookId } = input;
+
+    const existing = await this.favoriteRepository.findByUserAndBook(userId, bookId);
+
+    if (existing) {
+      await this.favoriteRepository.remove(userId, bookId);
+      return { favorite: false };
+    }
+
+    const favorite = Favorite.create(userId, bookId);
+    await this.favoriteRepository.add(favorite);
+    return { favorite: true };
+  }
+}

--- a/apps/api/src/domain/book/value-objects/BookId.ts
+++ b/apps/api/src/domain/book/value-objects/BookId.ts
@@ -1,0 +1,66 @@
+/**
+ * BookId Value Object
+ *
+ * Represents a unique identifier for a Book in the digital library, backed by a UUID v4.
+ *
+ * Value Objects are:
+ * - Immutable
+ * - Compared by value, not identity
+ * - Self-validating
+ *
+ * HU-039: BookId VO for favorites and downloads domain.
+ */
+
+import { InvalidUUIDError } from '../../errors/DomainErrors.js';
+import { isValidUUID } from '../../validators/index.js';
+import { randomUUID } from 'crypto';
+
+export class BookId {
+  private constructor(public readonly value: string) {
+    Object.freeze(this);
+  }
+
+  /**
+   * Creates a BookId from an existing UUID string with validation.
+   * @throws InvalidUUIDError if the value is not a valid UUID v4
+   */
+  static create(value: string): BookId {
+    if (!value || value.trim().length === 0) {
+      throw new InvalidUUIDError(value);
+    }
+
+    const trimmed = value.trim();
+
+    if (!isValidUUID(trimmed)) {
+      throw new InvalidUUIDError(value);
+    }
+
+    return new BookId(trimmed);
+  }
+
+  /**
+   * Generates a new BookId with a freshly generated UUID v4.
+   */
+  static generate(): BookId {
+    return new BookId(randomUUID());
+  }
+
+  /**
+   * Creates a BookId from a known valid value (no validation).
+   * Use only when the value comes from a trusted source (e.g., database).
+   */
+  static fromPersistence(value: string): BookId {
+    return new BookId(value);
+  }
+
+  /**
+   * Compares two BookId instances by value.
+   */
+  equals(other: BookId): boolean {
+    return this.value === other.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/apps/api/src/domain/download/Download.ts
+++ b/apps/api/src/domain/download/Download.ts
@@ -1,0 +1,56 @@
+/**
+ * Download Entity
+ *
+ * Represents a book download event for a user.
+ *
+ * Entities are:
+ * - Identified by the composite (userId, bookId)
+ * - Immutable (all state is set at construction time)
+ * - Responsible for maintaining their own invariants
+ *
+ * HU-039: Downloads domain entity.
+ */
+
+import { UserId } from '../user/value-objects/UserId.js';
+import { BookId } from '../book/value-objects/BookId.js';
+
+export interface DownloadPersistenceProps {
+  userId: string;
+  bookId: string;
+  downloadedAt: Date;
+}
+
+export class Download {
+  private constructor(
+    public readonly userId: UserId,
+    public readonly bookId: BookId,
+    public readonly downloadedAt: Date,
+  ) {
+    Object.freeze(this);
+  }
+
+  /**
+   * Creates a new Download with current timestamp.
+   * Use this when a user downloads a book.
+   */
+  static create(userId: UserId, bookId: BookId): Download {
+    return new Download(userId, bookId, new Date());
+  }
+
+  /**
+   * Reconstructs a Download from persistence data without re-validation.
+   * Use this when loading a download record from the database.
+   */
+  static fromPersistence(props: DownloadPersistenceProps): Download {
+    const userId = UserId.fromPersistence(props.userId);
+    const bookId = BookId.fromPersistence(props.bookId);
+    return new Download(userId, bookId, props.downloadedAt);
+  }
+
+  /**
+   * Compares two Download instances by their composite key.
+   */
+  equals(other: Download): boolean {
+    return this.userId.equals(other.userId) && this.bookId.equals(other.bookId);
+  }
+}

--- a/apps/api/src/domain/download/ports/DownloadRepository.ts
+++ b/apps/api/src/domain/download/ports/DownloadRepository.ts
@@ -1,0 +1,23 @@
+/**
+ * DownloadRepository Port (Driven/Output Port)
+ *
+ * Defines the contract for download persistence operations.
+ * This is a pure domain port — no infrastructure dependencies.
+ *
+ * HU-039: Downloads domain port for persistence.
+ */
+
+import type { Download } from '../Download.js';
+
+/**
+ * DownloadRepository Port Interface
+ *
+ * Provides operations for managing download records in the persistence layer.
+ */
+export interface DownloadRepository {
+  /**
+   * Creates or updates a download record for the (userId, bookId) pair.
+   * Updates the downloadedAt timestamp if the record already exists.
+   */
+  upsert(download: Download): Promise<void>;
+}

--- a/apps/api/src/domain/favorite/Favorite.ts
+++ b/apps/api/src/domain/favorite/Favorite.ts
@@ -1,0 +1,56 @@
+/**
+ * Favorite Entity
+ *
+ * Represents a book marked as favorite by a user.
+ *
+ * Entities are:
+ * - Identified by the composite (userId, bookId)
+ * - Immutable (all state is set at construction time)
+ * - Responsible for maintaining their own invariants
+ *
+ * HU-039: Favorites domain entity.
+ */
+
+import { UserId } from '../user/value-objects/UserId.js';
+import { BookId } from '../book/value-objects/BookId.js';
+
+export interface FavoritePersistenceProps {
+  userId: string;
+  bookId: string;
+  createdAt: Date;
+}
+
+export class Favorite {
+  private constructor(
+    public readonly userId: UserId,
+    public readonly bookId: BookId,
+    public readonly createdAt: Date,
+  ) {
+    Object.freeze(this);
+  }
+
+  /**
+   * Creates a new Favorite with current timestamp.
+   * Use this when a user marks a book as favorite.
+   */
+  static create(userId: UserId, bookId: BookId): Favorite {
+    return new Favorite(userId, bookId, new Date());
+  }
+
+  /**
+   * Reconstructs a Favorite from persistence data without re-validation.
+   * Use this when loading a favorite from the database.
+   */
+  static fromPersistence(props: FavoritePersistenceProps): Favorite {
+    const userId = UserId.fromPersistence(props.userId);
+    const bookId = BookId.fromPersistence(props.bookId);
+    return new Favorite(userId, bookId, props.createdAt);
+  }
+
+  /**
+   * Compares two Favorite instances by their composite key.
+   */
+  equals(other: Favorite): boolean {
+    return this.userId.equals(other.userId) && this.bookId.equals(other.bookId);
+  }
+}

--- a/apps/api/src/domain/favorite/ports/FavoriteRepository.ts
+++ b/apps/api/src/domain/favorite/ports/FavoriteRepository.ts
@@ -1,0 +1,43 @@
+/**
+ * FavoriteRepository Port (Driven/Output Port)
+ *
+ * Defines the contract for favorite persistence operations.
+ * This is a pure domain port — no infrastructure dependencies.
+ *
+ * HU-039: Favorites domain port for persistence.
+ */
+
+import type { Favorite } from '../Favorite.js';
+import type { UserId } from '../../user/value-objects/UserId.js';
+import type { BookId } from '../../book/value-objects/BookId.js';
+
+/**
+ * FavoriteRepository Port Interface
+ *
+ * Provides operations for managing favorites in the persistence layer.
+ */
+export interface FavoriteRepository {
+  /**
+   * Finds a favorite by user and book composite key.
+   *
+   * @returns Promise resolving to the Favorite if found, null otherwise
+   */
+  findByUserAndBook(userId: UserId, bookId: BookId): Promise<Favorite | null>;
+
+  /**
+   * Persists a new favorite.
+   */
+  add(favorite: Favorite): Promise<void>;
+
+  /**
+   * Removes a favorite by user and book composite key.
+   */
+  remove(userId: UserId, bookId: BookId): Promise<void>;
+
+  /**
+   * Finds all book IDs favorited by a given user.
+   *
+   * @returns Promise resolving to an array of BookId
+   */
+  findAllByUser(userId: UserId): Promise<BookId[]>;
+}

--- a/apps/api/src/infrastructure/driven/auth/JwtServiceImpl.ts
+++ b/apps/api/src/infrastructure/driven/auth/JwtServiceImpl.ts
@@ -81,7 +81,7 @@ export class JwtServiceImpl implements JwtService {
 
       return { userId: decoded.userId, email: decoded.email };
     } catch (err) {
-      if (err instanceof InvalidCredentialsError) throw err;
+      if (err instanceof InvalidCredentialsError) {throw err;}
       throw new InvalidCredentialsError();
     }
   }

--- a/apps/api/src/infrastructure/driven/persistence/DrizzleDownloadRepository.ts
+++ b/apps/api/src/infrastructure/driven/persistence/DrizzleDownloadRepository.ts
@@ -1,0 +1,44 @@
+/**
+ * DrizzleDownloadRepository Adapter
+ *
+ * Implements the DownloadRepository port using Drizzle ORM with PostgreSQL.
+ * This is a driven/output adapter in the hexagonal architecture.
+ *
+ * HU-039: Persistence adapter for Download entity.
+ */
+
+import type { DownloadRepository } from '../../../domain/download/ports/DownloadRepository.js';
+import type { Download } from '../../../domain/download/Download.js';
+import { userBookDownloads } from './drizzle/schema.js';
+import type { DatabaseClient } from './types.js';
+
+/**
+ * DrizzleDownloadRepository
+ *
+ * Adapter that implements DownloadRepository using Drizzle ORM.
+ * Uses INSERT ... ON CONFLICT DO UPDATE (upsert) to handle repeated downloads.
+ */
+export class DrizzleDownloadRepository implements DownloadRepository {
+  constructor(private readonly db: DatabaseClient) {}
+
+  /**
+   * Creates or updates a download record for the (userId, bookId) pair.
+   *
+   * Uses PostgreSQL's ON CONFLICT DO UPDATE to atomically upsert the record.
+   * If a record already exists for the (userId, bookId) pair, only the
+   * downloadedAt timestamp is updated.
+   */
+  async upsert(download: Download): Promise<void> {
+    await this.db
+      .insert(userBookDownloads)
+      .values({
+        userId: download.userId.value,
+        bookId: download.bookId.value,
+        downloadedAt: download.downloadedAt,
+      })
+      .onConflictDoUpdate({
+        target: [userBookDownloads.userId, userBookDownloads.bookId],
+        set: { downloadedAt: new Date() },
+      });
+  }
+}

--- a/apps/api/src/infrastructure/driven/persistence/DrizzleFavoriteRepository.ts
+++ b/apps/api/src/infrastructure/driven/persistence/DrizzleFavoriteRepository.ts
@@ -1,0 +1,87 @@
+/**
+ * DrizzleFavoriteRepository Adapter
+ *
+ * Implements the FavoriteRepository port using Drizzle ORM with PostgreSQL.
+ * This is a driven/output adapter in the hexagonal architecture.
+ *
+ * HU-039: Persistence adapter for Favorite entity.
+ */
+
+import { eq, and } from 'drizzle-orm';
+import type { FavoriteRepository } from '../../../domain/favorite/ports/FavoriteRepository.js';
+import { Favorite } from '../../../domain/favorite/Favorite.js';
+import type { UserId } from '../../../domain/user/value-objects/UserId.js';
+import type { BookId } from '../../../domain/book/value-objects/BookId.js';
+import { BookId as BookIdVO } from '../../../domain/book/value-objects/BookId.js';
+import { userBookFavorites, type UserBookFavoriteSelect } from './drizzle/schema.js';
+import type { DatabaseClient } from './types.js';
+
+/**
+ * Maps a Drizzle UserBookFavoriteSelect row to a Favorite domain entity
+ */
+function toDomain(row: UserBookFavoriteSelect): Favorite {
+  return Favorite.fromPersistence({
+    userId: row.userId,
+    bookId: row.bookId,
+    createdAt: row.createdAt ?? new Date(),
+  });
+}
+
+/**
+ * DrizzleFavoriteRepository
+ *
+ * Adapter that implements FavoriteRepository using Drizzle ORM.
+ */
+export class DrizzleFavoriteRepository implements FavoriteRepository {
+  constructor(private readonly db: DatabaseClient) {}
+
+  /**
+   * Finds a favorite by composite key (userId, bookId)
+   */
+  async findByUserAndBook(userId: UserId, bookId: BookId): Promise<Favorite | null> {
+    const row = await this.db.query.userBookFavorites.findFirst({
+      where: and(
+        eq(userBookFavorites.userId, userId.value),
+        eq(userBookFavorites.bookId, bookId.value),
+      ),
+    });
+
+    return row ? toDomain(row) : null;
+  }
+
+  /**
+   * Persists a new favorite record
+   */
+  async add(favorite: Favorite): Promise<void> {
+    await this.db.insert(userBookFavorites).values({
+      userId: favorite.userId.value,
+      bookId: favorite.bookId.value,
+      createdAt: favorite.createdAt,
+    });
+  }
+
+  /**
+   * Removes a favorite by composite key (userId, bookId)
+   */
+  async remove(userId: UserId, bookId: BookId): Promise<void> {
+    await this.db
+      .delete(userBookFavorites)
+      .where(
+        and(
+          eq(userBookFavorites.userId, userId.value),
+          eq(userBookFavorites.bookId, bookId.value),
+        ),
+      );
+  }
+
+  /**
+   * Finds all bookIds favorited by a given user
+   */
+  async findAllByUser(userId: UserId): Promise<BookId[]> {
+    const rows = await this.db.query.userBookFavorites.findMany({
+      where: eq(userBookFavorites.userId, userId.value),
+    });
+
+    return rows.map((row) => BookIdVO.fromPersistence(row.bookId));
+  }
+}

--- a/apps/api/src/infrastructure/driven/persistence/DrizzlePasswordResetTokenRepository.ts
+++ b/apps/api/src/infrastructure/driven/persistence/DrizzlePasswordResetTokenRepository.ts
@@ -69,10 +69,10 @@ export class DrizzlePasswordResetTokenRepository implements PasswordResetTokenRe
       ),
     });
 
-    if (!row) return null;
+    if (!row) {return null;}
 
     // Check expiry in application layer (avoids SQL gt import complexity)
-    if (row.expiresAt <= now) return null;
+    if (row.expiresAt <= now) {return null;}
 
     return toDomain(row);
   }

--- a/apps/api/src/infrastructure/driven/persistence/PostgresBookRepository.ts
+++ b/apps/api/src/infrastructure/driven/persistence/PostgresBookRepository.ts
@@ -22,7 +22,7 @@
  * - Book now uses levelId (UUID FK to levels table) instead of level enum
  */
 
-import { eq, count, and, ilike, sql, asc, desc } from 'drizzle-orm';
+import { eq, count, and, ilike, sql, asc, desc, inArray } from 'drizzle-orm';
 import type { Book } from '../../../domain/entities/Book.js';
 import type { Author } from '../../../domain/entities/Author.js';
 import type { BookType } from '../../../domain/entities/BookType.js';
@@ -39,6 +39,7 @@ import type {
   SearchBooksResult,
   BookWithScore,
 } from '../../../application/ports/BookRepository.js';
+import type { BookId } from '../../../domain/book/value-objects/BookId.js';
 import {
   books,
   bookAuthors,
@@ -381,9 +382,20 @@ export class PostgresBookRepository implements BookRepository {
    *
    * @param criteria - Domain criteria object with filters, order, limit, cursor
    * @param embedding - Optional embedding vector for semantic search (SIMILAR_TO filter)
+   * @param favoritesOf - Optional list of BookIds to restrict results to (favorites filter)
    * @returns Promise resolving to paginated search results with similarity scores
    */
-  async search(criteria: Criteria, embedding?: number[]): Promise<SearchBooksResult> {
+  async search(criteria: Criteria, embedding?: number[], favoritesOf?: BookId[]): Promise<SearchBooksResult> {
+    // Short-circuit: if favorites filter is requested but list is empty, return empty result
+    if (favoritesOf !== undefined && favoritesOf.length === 0) {
+      return {
+        items: [],
+        totalCount: 0,
+        hasNextPage: false,
+        nextCursor: null,
+      };
+    }
+
     const hasEmbedding = embedding !== undefined && embedding.length > 0;
 
     // Build where conditions from criteria filters
@@ -391,6 +403,7 @@ export class PostgresBookRepository implements BookRepository {
       criteria,
       embedding,
       SEMANTIC_SEARCH.SIMILARITY_THRESHOLD,
+      favoritesOf,
     );
 
     // Build the order by clause
@@ -446,6 +459,7 @@ export class PostgresBookRepository implements BookRepository {
     criteria: Criteria,
     embedding: number[] | undefined,
     similarityThreshold: number,
+    favoritesOf?: BookId[],
   ): ReturnType<typeof and> {
     const conditions: ReturnType<typeof eq>[] = [];
 
@@ -463,6 +477,12 @@ export class PostgresBookRepository implements BookRepository {
       conditions.push(
         sql`1 - (${books.embedding} <=> ${embeddingStr}::vector) >= ${similarityThreshold}`,
       );
+    }
+
+    // Add favorites filter if provided (non-empty, already guarded at search() level)
+    if (favoritesOf && favoritesOf.length > 0) {
+      const bookIdStrings = favoritesOf.map((id) => id.value);
+      conditions.push(inArray(books.id, bookIdStrings) as ReturnType<typeof eq>);
     }
 
     return conditions.length > 0 ? and(...conditions) : undefined;

--- a/apps/api/src/infrastructure/driven/persistence/drizzle/schema.ts
+++ b/apps/api/src/infrastructure/driven/persistence/drizzle/schema.ts
@@ -42,13 +42,22 @@ export const types = pgTable('types', {
 ]);
 
 /**
- * Levels table (HU-008)
+ * Changes in HU-002:
+ * - Added 'types' table (replaces book_type enum)
+ * - Added 'authors' table with N:M relationship to books
+ * - Added 'book_authors' junction table
+ * - Modified 'books' table: removed author column, added type_id reference
  *
- * Stores difficulty level classifications for books.
- * Replaces the book_level enum with dynamic values.
- * Examples: Beginner, Intermediate, Advanced
+ * Changes in HU-008:
+ * - Removed 'book_level' enum (replaced by 'levels' table)
+ * - Added 'levels' table for dynamic level values
+ * - Added 'type_levels' junction table for N:N relationship between types and levels
+ * - Added 'type_id' to 'categories' table (1:N relationship with types)
+ * - Changed 'books.level' to 'books.level_id' as FK to levels table
  *
- * Has N:N relationship with types via type_levels junction table.
+ * Changes in HU-039:
+ * - Added 'user_book_favorites' junction table (user ↔ book favorites)
+ * - Added 'user_book_downloads' junction table (user ↔ book downloads)
  */
 export const levels = pgTable('levels', {
   id: uuid('id').primaryKey(),
@@ -249,3 +258,40 @@ export type UserInsert = typeof users.$inferInsert;
 export type UserSelect = typeof users.$inferSelect;
 export type PasswordResetTokenInsert = typeof passwordResetTokens.$inferInsert;
 export type PasswordResetTokenSelect = typeof passwordResetTokens.$inferSelect;
+
+/**
+ * User-Book Favorites junction table (HU-039)
+ *
+ * Tracks which books a user has marked as favorites.
+ * Composite primary key (user_id, book_id) prevents duplicates.
+ */
+export const userBookFavorites = pgTable('user_book_favorites', {
+  userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  bookId: uuid('book_id').notNull().references(() => books.id, { onDelete: 'cascade' }),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+}, (table) => [
+  // Composite primary key
+  primaryKey({ columns: [table.userId, table.bookId] }),
+  // Index for querying favorites by user
+  index('user_book_favorites_user_idx').on(table.userId),
+]);
+
+/**
+ * User-Book Downloads junction table (HU-039)
+ *
+ * Tracks which books a user has downloaded.
+ * Composite primary key (user_id, book_id) — one record per user+book pair.
+ */
+export const userBookDownloads = pgTable('user_book_downloads', {
+  userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  bookId: uuid('book_id').notNull().references(() => books.id, { onDelete: 'cascade' }),
+  downloadedAt: timestamp('downloaded_at', { withTimezone: true }).defaultNow(),
+}, (table) => [
+  // Composite primary key
+  primaryKey({ columns: [table.userId, table.bookId] }),
+]);
+
+export type UserBookFavoriteInsert = typeof userBookFavorites.$inferInsert;
+export type UserBookFavoriteSelect = typeof userBookFavorites.$inferSelect;
+export type UserBookDownloadInsert = typeof userBookDownloads.$inferInsert;
+export type UserBookDownloadSelect = typeof userBookDownloads.$inferSelect;

--- a/apps/api/src/infrastructure/driven/persistence/index.ts
+++ b/apps/api/src/infrastructure/driven/persistence/index.ts
@@ -9,6 +9,9 @@ export { PostgresBookRepository, normalizeForDuplicateCheck } from './PostgresBo
 export { PostgresAuthorRepository } from './PostgresAuthorRepository.js';
 export { PostgresTypeRepository } from './PostgresTypeRepository.js';
 export { PostgresLevelRepository } from './PostgresLevelRepository.js';
+export { DrizzleUserRepository } from './DrizzleUserRepository.js';
+export { DrizzleFavoriteRepository } from './DrizzleFavoriteRepository.js';
+export { DrizzleDownloadRepository } from './DrizzleDownloadRepository.js';
 export type { DatabaseClient } from './types.js';
 export * from './drizzle/schema.js';
 export * from './mappers/index.js';

--- a/apps/api/src/infrastructure/driver/http/controllers/FavoriteController.ts
+++ b/apps/api/src/infrastructure/driver/http/controllers/FavoriteController.ts
@@ -1,0 +1,97 @@
+/**
+ * FavoriteController
+ *
+ * HTTP request handler for the POST /api/books/:id/favorite endpoint.
+ * Follows the thin controller pattern — delegates business logic to use cases.
+ *
+ * HU-039: Toggle favorite HTTP controller.
+ */
+
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import type { ToggleFavoriteUseCase } from '../../../../application/use-cases/favorite/ToggleFavoriteUseCase.js';
+import type { JwtService } from '../../../../domain/user/ports/JwtService.js';
+import type { Logger } from '../../../../application/ports/Logger.js';
+import { noopLogger } from '../../../../application/ports/Logger.js';
+import { requireAuth } from '../middleware/requireAuth.js';
+import { successResponse } from '../schemas/common.schemas.js';
+import { mapErrorToHttpResponse } from '../errors/HttpErrorMapper.js';
+import { BookId } from '../../../../domain/book/value-objects/BookId.js';
+
+/**
+ * Dependencies required by FavoriteController
+ */
+export interface FavoriteControllerDeps {
+  toggleFavoriteUseCase: ToggleFavoriteUseCase;
+  jwtService: JwtService;
+  logger?: Logger;
+}
+
+/**
+ * FavoriteController
+ *
+ * Handles HTTP requests for favorite book operations.
+ */
+export class FavoriteController {
+  private readonly toggleFavoriteUseCase: ToggleFavoriteUseCase;
+  private readonly jwtService: JwtService;
+  private readonly logger: Logger;
+
+  constructor(deps: FavoriteControllerDeps) {
+    this.toggleFavoriteUseCase = deps.toggleFavoriteUseCase;
+    this.jwtService = deps.jwtService;
+    this.logger = deps.logger?.child({ name: 'FavoriteController' }) ?? noopLogger;
+  }
+
+  /**
+   * POST /api/books/:id/favorite
+   *
+   * Toggles a book as favorite for the authenticated user.
+   *
+   * @returns 200 { favorite: boolean } on success
+   * @returns 401 if not authenticated
+   * @returns 404 if the book does not exist
+   */
+  async toggleFavorite(
+    request: FastifyRequest<{ Params: { id: string } }>,
+    reply: FastifyReply,
+  ): Promise<FastifyReply> {
+    const bookIdRaw = request.params.id;
+    this.logger.debug('Received toggle favorite request', { bookId: bookIdRaw });
+
+    try {
+      // 1. Require authentication
+      const userId = await requireAuth(request, reply, this.jwtService);
+
+      // If requireAuth sent a 401, reply is already sent — stop processing
+      if (reply.sent) {
+        return reply;
+      }
+
+      // 2. Validate bookId
+      const bookId = BookId.create(bookIdRaw);
+
+      // 3. Execute use case
+      const result = await this.toggleFavoriteUseCase.execute({ userId, bookId });
+
+      this.logger.info('Favorite toggled', { bookId: bookIdRaw, favorite: result.favorite });
+
+      return reply.status(200).send(successResponse(result));
+    } catch (error) {
+      // If reply was already sent (401 from requireAuth), just return
+      if (reply.sent) {
+        return reply;
+      }
+
+      const errorResponse = mapErrorToHttpResponse(error);
+
+      if (errorResponse.statusCode >= 500) {
+        this.logger.error('Unexpected error toggling favorite', {
+          bookId: bookIdRaw,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
+      return reply.status(errorResponse.statusCode).send(errorResponse.body);
+    }
+  }
+}

--- a/apps/api/src/infrastructure/driver/http/controllers/SearchBooksController.ts
+++ b/apps/api/src/infrastructure/driver/http/controllers/SearchBooksController.ts
@@ -9,17 +9,20 @@
 
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import type { SearchBooksUseCase } from '../../../../application/use-cases/SearchBooksUseCase.js';
+import type { JwtService } from '../../../../domain/user/ports/JwtService.js';
 import type { Logger } from '../../../../application/ports/Logger.js';
 import { noopLogger } from '../../../../application/ports/Logger.js';
 import { searchBooksQuerySchema } from '../schemas/search-books.schemas.js';
 import { successResponse } from '../schemas/common.schemas.js';
 import { mapErrorToHttpResponse } from '../errors/HttpErrorMapper.js';
+import { extractUserIfPresent } from '../middleware/extractUserIfPresent.js';
 
 /**
  * Dependencies required by SearchBooksController
  */
 export interface SearchBooksControllerDeps {
   searchBooksUseCase: SearchBooksUseCase;
+  jwtService?: JwtService;
   logger?: Logger;
 }
 
@@ -35,10 +38,12 @@ export interface SearchBooksControllerDeps {
  */
 export class SearchBooksController {
   private readonly searchBooksUseCase: SearchBooksUseCase;
+  private readonly jwtService: JwtService | undefined;
   private readonly logger: Logger;
 
   constructor(deps: SearchBooksControllerDeps) {
     this.searchBooksUseCase = deps.searchBooksUseCase;
+    this.jwtService = deps.jwtService;
     this.logger = deps.logger?.child({ name: 'SearchBooksController' }) ?? noopLogger;
   }
 
@@ -86,6 +91,14 @@ export class SearchBooksController {
 
       const query = parseResult.data;
 
+      // HU-039: Extract optional user identity for favorites filter
+      const userId = this.jwtService
+        ? await extractUserIfPresent(request, this.jwtService)
+        : undefined;
+
+      // HU-039: Only apply favorites filter if user is authenticated
+      const favoritesOf = query.favorites && userId ? userId : undefined;
+
       // 2. Execute use case
       const result = await this.searchBooksUseCase.execute({
         isbn: query.isbn,
@@ -97,6 +110,7 @@ export class SearchBooksController {
         levels: query.levels,
         limit: query.limit,
         cursor: query.cursor,
+        favoritesOf,
       });
 
       // 3. Return search results with standardized response structure

--- a/apps/api/src/infrastructure/driver/http/controllers/SendBookByEmailController.ts
+++ b/apps/api/src/infrastructure/driver/http/controllers/SendBookByEmailController.ts
@@ -9,17 +9,23 @@
 
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import type { SendBookByEmailUseCase } from '../../../../application/use-cases/SendBookByEmailUseCase.js';
+import type { RegisterDownloadUseCase } from '../../../../application/use-cases/download/RegisterDownloadUseCase.js';
+import type { JwtService } from '../../../../domain/user/ports/JwtService.js';
 import type { Logger } from '../../../../application/ports/Logger.js';
 import { noopLogger } from '../../../../application/ports/Logger.js';
 import { sendBookByEmailSchema } from '../schemas/send-book.schemas.js';
 import { successResponse } from '../schemas/common.schemas.js';
 import { mapErrorToHttpResponse } from '../errors/HttpErrorMapper.js';
+import { extractUserIfPresent } from '../middleware/extractUserIfPresent.js';
+import { BookId } from '../../../../domain/book/value-objects/BookId.js';
 
 /**
  * Dependencies required by SendBookByEmailController
  */
 export interface SendBookByEmailControllerDeps {
   sendBookByEmailUseCase: SendBookByEmailUseCase;
+  registerDownloadUseCase?: RegisterDownloadUseCase;
+  jwtService?: JwtService;
   logger?: Logger;
 }
 
@@ -30,10 +36,14 @@ export interface SendBookByEmailControllerDeps {
  */
 export class SendBookByEmailController {
   private readonly sendBookByEmailUseCase: SendBookByEmailUseCase;
+  private readonly registerDownloadUseCase: RegisterDownloadUseCase | undefined;
+  private readonly jwtService: JwtService | undefined;
   private readonly logger: Logger;
 
   constructor(deps: SendBookByEmailControllerDeps) {
     this.sendBookByEmailUseCase = deps.sendBookByEmailUseCase;
+    this.registerDownloadUseCase = deps.registerDownloadUseCase;
+    this.jwtService = deps.jwtService;
     this.logger = deps.logger?.child({ name: 'SendBookByEmailController' }) ?? noopLogger;
   }
 
@@ -72,6 +82,32 @@ export class SendBookByEmailController {
 
       // 2. Execute use case
       await this.sendBookByEmailUseCase.execute({ bookId, email });
+
+      // HU-039: Register download if user is authenticated (fire-and-forget, never blocks)
+      if (this.registerDownloadUseCase && this.jwtService) {
+        const registerDownload = this.registerDownloadUseCase;
+        extractUserIfPresent(request, this.jwtService)
+          .then((userId) => {
+            if (!userId) {return;}
+            try {
+              const bookIdVO = BookId.create(bookId);
+              registerDownload.execute({ userId, bookId: bookIdVO }).catch((err) => {
+                this.logger.debug('Failed to register download (non-blocking)', {
+                  bookId,
+                  error: err instanceof Error ? err.message : String(err),
+                });
+              });
+            } catch {
+              // Invalid bookId — ignore
+            }
+          })
+          .catch((err) => {
+            this.logger.debug('Failed to extract user for download registration', {
+              bookId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
+      }
 
       // 3. Return success
       this.logger.info('Book sent by email', { bookId, email });

--- a/apps/api/src/infrastructure/driver/http/middleware/extractUserIfPresent.ts
+++ b/apps/api/src/infrastructure/driver/http/middleware/extractUserIfPresent.ts
@@ -1,0 +1,41 @@
+/**
+ * extractUserIfPresent
+ *
+ * Reads the access_token cookie from a Fastify request.
+ * If the token is present and valid, returns the UserId.
+ * If the token is absent or invalid, returns undefined — never throws.
+ *
+ * HU-039: Optional auth extraction for endpoints that support both
+ * authenticated and unauthenticated access.
+ */
+
+import type { FastifyRequest } from 'fastify';
+import type { JwtService } from '../../../../domain/user/ports/JwtService.js';
+import { UserId } from '../../../../domain/user/value-objects/UserId.js';
+
+const COOKIE_ACCESS_TOKEN = 'access_token';
+
+/**
+ * Extracts the authenticated UserId from the request cookie, if present and valid.
+ *
+ * @param request - Fastify request
+ * @param jwtService - JWT service for token verification
+ * @returns UserId if authenticated, undefined otherwise
+ */
+export async function extractUserIfPresent(
+  request: FastifyRequest,
+  jwtService: JwtService,
+): Promise<UserId | undefined> {
+  const token = request.cookies?.[COOKIE_ACCESS_TOKEN];
+
+  if (!token) {
+    return undefined;
+  }
+
+  try {
+    const payload = await jwtService.verifyAccessToken(token);
+    return UserId.create(payload.userId);
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/api/src/infrastructure/driver/http/middleware/requireAuth.ts
+++ b/apps/api/src/infrastructure/driver/http/middleware/requireAuth.ts
@@ -1,0 +1,48 @@
+/**
+ * requireAuth
+ *
+ * Reads the access_token cookie from a Fastify request.
+ * If the token is present and valid, returns the UserId.
+ * If the token is absent or invalid, sends a 401 response and throws
+ * to stop handler execution.
+ *
+ * HU-039: Mandatory auth guard for protected endpoints.
+ */
+
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import type { JwtService } from '../../../../domain/user/ports/JwtService.js';
+import { UserId } from '../../../../domain/user/value-objects/UserId.js';
+import { errorResponse } from '../schemas/common.schemas.js';
+
+const COOKIE_ACCESS_TOKEN = 'access_token';
+
+/**
+ * Extracts the authenticated UserId from the request cookie.
+ * Sends 401 and throws if the token is missing or invalid.
+ *
+ * @param request - Fastify request
+ * @param reply - Fastify reply (used to send 401 response)
+ * @param jwtService - JWT service for token verification
+ * @returns UserId of the authenticated user
+ * @throws If the token is missing or invalid (after sending 401)
+ */
+export async function requireAuth(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  jwtService: JwtService,
+): Promise<UserId> {
+  const token = request.cookies?.[COOKIE_ACCESS_TOKEN];
+
+  if (!token) {
+    await reply.code(401).send(errorResponse('Authentication required'));
+    throw new Error('Unauthorized');
+  }
+
+  try {
+    const payload = await jwtService.verifyAccessToken(token);
+    return UserId.create(payload.userId);
+  } catch {
+    await reply.code(401).send(errorResponse('Invalid or expired token'));
+    throw new Error('Unauthorized');
+  }
+}

--- a/apps/api/src/infrastructure/driver/http/routes/books.routes.ts
+++ b/apps/api/src/infrastructure/driver/http/routes/books.routes.ts
@@ -11,6 +11,7 @@ import type { FastifyInstance, FastifyPluginOptions } from 'fastify';
 import type { BooksController } from '../controllers/BooksController.js';
 import type { SearchBooksController } from '../controllers/SearchBooksController.js';
 import type { SendBookByEmailController } from '../controllers/SendBookByEmailController.js';
+import type { FavoriteController } from '../controllers/FavoriteController.js';
 
 /**
  * Options for registering book routes
@@ -19,6 +20,7 @@ export interface BooksRoutesOptions extends FastifyPluginOptions {
   controller: BooksController;
   searchController: SearchBooksController;
   sendBookByEmailController: SendBookByEmailController;
+  favoriteController?: FavoriteController;
 }
 
 /**
@@ -28,6 +30,7 @@ export interface BooksRoutesOptions extends FastifyPluginOptions {
  * - GET /api/books - Search books with filters and pagination
  * - POST /api/books - Create a new book
  * - POST /api/books/:id/send - Send a book by email (HU-036)
+ * - POST /api/books/:id/favorite - Toggle favorite (HU-039)
  *
  * @param fastify - Fastify instance
  * @param options - Route options including controllers
@@ -36,7 +39,7 @@ export async function booksRoutes(
   fastify: FastifyInstance,
   options: BooksRoutesOptions,
 ): Promise<void> {
-  const { controller, searchController, sendBookByEmailController } = options;
+  const { controller, searchController, sendBookByEmailController, favoriteController } = options;
 
   /**
    * GET /api/books
@@ -64,4 +67,17 @@ export async function booksRoutes(
       reply,
     );
   });
+
+  /**
+   * POST /api/books/:id/favorite
+   * Toggles a book as favorite for the authenticated user (HU-039)
+   */
+  if (favoriteController) {
+    fastify.post('/books/:id/favorite', async (request, reply) => {
+      return favoriteController.toggleFavorite(
+        request as Parameters<typeof favoriteController.toggleFavorite>[0],
+        reply,
+      );
+    });
+  }
 }

--- a/apps/api/src/infrastructure/driver/http/schemas/search-books.schemas.ts
+++ b/apps/api/src/infrastructure/driver/http/schemas/search-books.schemas.ts
@@ -90,6 +90,12 @@ export const searchBooksQuerySchema = z.object({
     .string()
     .min(1, 'Cursor cannot be empty')
     .optional(),
+
+  // HU-039: Filter to show only books favorited by the authenticated user
+  favorites: z
+    .union([z.literal('true'), z.literal('false'), z.boolean()])
+    .transform((val) => val === true || val === 'true')
+    .optional(),
 });
 
 /**

--- a/apps/api/src/infrastructure/driver/http/server.ts
+++ b/apps/api/src/infrastructure/driver/http/server.ts
@@ -25,6 +25,7 @@ import { BookTypesController } from './controllers/BookTypesController.js';
 import { CategoriesController } from './controllers/CategoriesController.js';
 import { BookLevelsController } from './controllers/BookLevelsController.js';
 import { SendBookByEmailController } from './controllers/SendBookByEmailController.js';
+import { FavoriteController } from './controllers/FavoriteController.js';
 import { AuthController } from './controllers/AuthController.js';
 import { booksRoutes } from './routes/books.routes.js';
 import { bookTypesRoutes } from './routes/book-types.routes.js';
@@ -37,11 +38,14 @@ import type { ListBookTypesUseCase } from '../../../application/use-cases/ListBo
 import type { ListCategoriesUseCase } from '../../../application/use-cases/ListCategoriesUseCase.js';
 import type { ListBookLevelsUseCase } from '../../../application/use-cases/ListBookLevelsUseCase.js';
 import type { SendBookByEmailUseCase } from '../../../application/use-cases/SendBookByEmailUseCase.js';
+import type { ToggleFavoriteUseCase } from '../../../application/use-cases/favorite/ToggleFavoriteUseCase.js';
+import type { RegisterDownloadUseCase } from '../../../application/use-cases/download/RegisterDownloadUseCase.js';
 import type { LoginUseCase } from '../../../application/use-cases/auth/LoginUseCase.js';
 import type { LogoutUseCase } from '../../../application/use-cases/auth/LogoutUseCase.js';
 import type { RefreshTokenUseCase } from '../../../application/use-cases/auth/RefreshTokenUseCase.js';
 import type { ForgotPasswordUseCase } from '../../../application/use-cases/auth/ForgotPasswordUseCase.js';
 import type { ResetPasswordUseCase } from '../../../application/use-cases/auth/ResetPasswordUseCase.js';
+import type { JwtService } from '../../../domain/user/ports/JwtService.js';
 
 /**
  * Dependencies required by the server
@@ -53,11 +57,14 @@ export interface ServerDeps {
   listCategoriesUseCase: ListCategoriesUseCase;
   listBookLevelsUseCase: ListBookLevelsUseCase;
   sendBookByEmailUseCase: SendBookByEmailUseCase;
+  toggleFavoriteUseCase?: ToggleFavoriteUseCase;
+  registerDownloadUseCase?: RegisterDownloadUseCase;
   loginUseCase: LoginUseCase;
   logoutUseCase: LogoutUseCase;
   refreshTokenUseCase: RefreshTokenUseCase;
   forgotPasswordUseCase: ForgotPasswordUseCase;
   resetPasswordUseCase: ResetPasswordUseCase;
+  jwtService?: JwtService;
   logger?: Logger;
 }
 
@@ -82,7 +89,7 @@ export async function createServer(
   deps: ServerDeps,
   options: ServerOptions = {},
 ): Promise<FastifyInstance> {
-  const { createBookUseCase, searchBooksUseCase, listBookTypesUseCase, listCategoriesUseCase, listBookLevelsUseCase, sendBookByEmailUseCase, loginUseCase, logoutUseCase, refreshTokenUseCase, forgotPasswordUseCase, resetPasswordUseCase, logger = noopLogger } = deps;
+  const { createBookUseCase, searchBooksUseCase, listBookTypesUseCase, listCategoriesUseCase, listBookLevelsUseCase, sendBookByEmailUseCase, toggleFavoriteUseCase, registerDownloadUseCase, loginUseCase, logoutUseCase, refreshTokenUseCase, forgotPasswordUseCase, resetPasswordUseCase, jwtService, logger = noopLogger } = deps;
   const { prefix = '/api', nodeEnv = 'production' } = options;
 
   const serverLogger = logger.child({ name: 'FastifyServer' });
@@ -128,6 +135,7 @@ export async function createServer(
 
   const searchBooksController = new SearchBooksController({
     searchBooksUseCase,
+    jwtService,
     logger,
   });
 
@@ -148,8 +156,15 @@ export async function createServer(
 
   const sendBookByEmailController = new SendBookByEmailController({
     sendBookByEmailUseCase,
+    registerDownloadUseCase,
+    jwtService,
     logger,
   });
+
+  // HU-039: FavoriteController (only created if use case and jwtService are provided)
+  const favoriteController = toggleFavoriteUseCase && jwtService
+    ? new FavoriteController({ toggleFavoriteUseCase, jwtService, logger })
+    : undefined;
 
   const authController = new AuthController({
     loginUseCase,
@@ -166,6 +181,7 @@ export async function createServer(
     controller: booksController,
     searchController: searchBooksController,
     sendBookByEmailController,
+    favoriteController,
   });
 
   await fastify.register(bookTypesRoutes, {
@@ -195,6 +211,7 @@ export async function createServer(
       { method: 'GET', path: `${prefix}/books` },
       { method: 'POST', path: `${prefix}/books` },
       { method: 'POST', path: `${prefix}/books/:id/send` },
+      { method: 'POST', path: `${prefix}/books/:id/favorite` },
       { method: 'GET', path: `${prefix}/book-types` },
       { method: 'GET', path: `${prefix}/book-categories` },
       { method: 'GET', path: `${prefix}/book-levels` },

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -25,6 +25,8 @@ import { ListBookTypesUseCase } from './application/use-cases/ListBookTypesUseCa
 import { ListCategoriesUseCase } from './application/use-cases/ListCategoriesUseCase.js';
 import { ListBookLevelsUseCase } from './application/use-cases/ListBookLevelsUseCase.js';
 import { SendBookByEmailUseCase } from './application/use-cases/SendBookByEmailUseCase.js';
+import { ToggleFavoriteUseCase } from './application/use-cases/favorite/ToggleFavoriteUseCase.js';
+import { RegisterDownloadUseCase } from './application/use-cases/download/RegisterDownloadUseCase.js';
 import { LoginUseCase } from './application/use-cases/auth/LoginUseCase.js';
 import { LogoutUseCase } from './application/use-cases/auth/LogoutUseCase.js';
 import { RefreshTokenUseCase } from './application/use-cases/auth/RefreshTokenUseCase.js';
@@ -34,6 +36,8 @@ import { JwtServiceImpl } from './infrastructure/driven/auth/JwtServiceImpl.js';
 import { Argon2PasswordHasher } from './infrastructure/driven/auth/Argon2PasswordHasher.js';
 import { DrizzleUserRepository } from './infrastructure/driven/persistence/DrizzleUserRepository.js';
 import { DrizzlePasswordResetTokenRepository } from './infrastructure/driven/persistence/DrizzlePasswordResetTokenRepository.js';
+import { DrizzleFavoriteRepository } from './infrastructure/driven/persistence/DrizzleFavoriteRepository.js';
+import { DrizzleDownloadRepository } from './infrastructure/driven/persistence/DrizzleDownloadRepository.js';
 import { GmailEmailAdapter } from './infrastructure/driven/email/GmailEmailAdapter.js';
 import { NodeFileSystemAdapter } from './infrastructure/driven/filesystem/NodeFileSystemAdapter.js';
 import { createServer, startServer } from './infrastructure/driver/http/server.js';
@@ -174,6 +178,12 @@ async function bootstrap(): Promise<void> {
       passwordHasher,
     });
 
+    // HU-039: Favorites and downloads use cases
+    const favoriteRepository = new DrizzleFavoriteRepository(db);
+    const downloadRepository = new DrizzleDownloadRepository(db);
+    const toggleFavoriteUseCase = new ToggleFavoriteUseCase({ favoriteRepository });
+    const registerDownloadUseCase = new RegisterDownloadUseCase({ downloadRepository });
+
     // Create and start server
     const server = await createServer(
       {
@@ -183,11 +193,14 @@ async function bootstrap(): Promise<void> {
         listCategoriesUseCase,
         listBookLevelsUseCase,
         sendBookByEmailUseCase,
+        toggleFavoriteUseCase,
+        registerDownloadUseCase,
         loginUseCase,
         logoutUseCase,
         refreshTokenUseCase,
         forgotPasswordUseCase,
         resetPasswordUseCase,
+        jwtService,
         logger,
       },
       { prefix: '/api', nodeEnv: env.app.nodeEnv },

--- a/apps/api/tests/e2e/http/favorites.e2e.test.ts
+++ b/apps/api/tests/e2e/http/favorites.e2e.test.ts
@@ -1,0 +1,339 @@
+/**
+ * E2E Tests: POST /api/books/:id/favorite, GET /api/books?favorites=true, POST /api/books/:id/send (download)
+ *
+ * End-to-end tests for HU-039 HTTP endpoints:
+ * - POST /api/books/:id/favorite: toggle favorite (auth required)
+ * - GET /api/books?favorites=true: filter by favorites (optional auth)
+ * - POST /api/books/:id/send: registers download when user is authenticated
+ *
+ * These tests use mock use cases — no database required.
+ *
+ * HU-039: Favorites and downloads HTTP endpoint tests.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { createServer } from '../../../src/infrastructure/driver/http/server.js';
+import { noopLogger } from '../../../src/application/ports/Logger.js';
+import { BookNotFoundError } from '../../../src/domain/errors/DomainErrors.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TEST_PORT = 3098;
+const BASE_URL = `http://127.0.0.1:${TEST_PORT}`;
+
+const VALID_BOOK_ID = '550e8400-e29b-41d4-a716-446655440000';
+const VALID_USER_ID = '660e8400-e29b-41d4-a716-446655440001';
+const VALID_TOKEN = 'valid-access-token';
+
+/** Minimal no-op stubs for use cases not under test */
+function makeNoopUseCases() {
+  return {
+    createBookUseCase: { execute: vi.fn().mockResolvedValue({}) },
+    listBookTypesUseCase: { execute: vi.fn().mockResolvedValue([]) },
+    listCategoriesUseCase: { execute: vi.fn().mockResolvedValue([]) },
+    listBookLevelsUseCase: { execute: vi.fn().mockResolvedValue([]) },
+    loginUseCase: { execute: vi.fn().mockResolvedValue({ accessToken: '', refreshToken: '' }) },
+    logoutUseCase: { execute: vi.fn().mockResolvedValue(undefined) },
+    refreshTokenUseCase: { execute: vi.fn().mockResolvedValue({ accessToken: '', refreshToken: '' }) },
+    forgotPasswordUseCase: { execute: vi.fn().mockResolvedValue(undefined) },
+    resetPasswordUseCase: { execute: vi.fn().mockResolvedValue(undefined) },
+  };
+}
+
+/**
+ * Creates a JwtService mock that accepts VALID_TOKEN and returns VALID_USER_ID.
+ */
+function makeJwtService() {
+  return {
+    signTokens: vi.fn(),
+    verifyAccessToken: vi.fn().mockImplementation(async (token: string) => {
+      if (token === VALID_TOKEN) {
+        return { userId: VALID_USER_ID, email: 'user@example.com' };
+      }
+      throw new Error('Invalid token');
+    }),
+    verifyRefreshToken: vi.fn(),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/books/:id/favorite
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/books/:id/favorite', () => {
+  let server: FastifyInstance;
+  let toggleFavoriteExecute: ReturnType<typeof vi.fn>;
+
+  beforeAll(async () => {
+    toggleFavoriteExecute = vi.fn();
+    const jwtService = makeJwtService();
+
+    server = await createServer(
+      {
+        ...makeNoopUseCases(),
+        searchBooksUseCase: {
+          execute: vi.fn().mockResolvedValue({ items: [], pagination: { limit: 50, hasNextPage: false, nextCursor: null, totalCount: 0 } }),
+        },
+        sendBookByEmailUseCase: { execute: vi.fn().mockResolvedValue(undefined) },
+        toggleFavoriteUseCase: { execute: toggleFavoriteExecute },
+        jwtService,
+        logger: noopLogger,
+      },
+      { prefix: '/api', nodeEnv: 'test' },
+    );
+    await server.listen({ port: TEST_PORT, host: '127.0.0.1' });
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it('should return 401 when no access_token cookie is present', async () => {
+    const response = await fetch(`${BASE_URL}/api/books/${VALID_BOOK_ID}/favorite`, {
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(401);
+    const body = await response.json() as { success: boolean };
+    expect(body.success).toBe(false);
+  });
+
+  it('should return 401 when access_token cookie is invalid', async () => {
+    const response = await fetch(`${BASE_URL}/api/books/${VALID_BOOK_ID}/favorite`, {
+      method: 'POST',
+      headers: { Cookie: 'access_token=invalid-token' },
+    });
+
+    expect(response.status).toBe(401);
+    const body = await response.json() as { success: boolean };
+    expect(body.success).toBe(false);
+  });
+
+  it('should return 200 with { favorite: true } when toggled on', async () => {
+    toggleFavoriteExecute.mockResolvedValueOnce({ favorite: true });
+
+    const response = await fetch(`${BASE_URL}/api/books/${VALID_BOOK_ID}/favorite`, {
+      method: 'POST',
+      headers: { Cookie: `access_token=${VALID_TOKEN}` },
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { success: boolean; data: { favorite: boolean } };
+    expect(body.success).toBe(true);
+    expect(body.data.favorite).toBe(true);
+
+    expect(toggleFavoriteExecute).toHaveBeenCalledTimes(1);
+    const callArg = toggleFavoriteExecute.mock.calls[0][0];
+    expect(callArg.userId.value).toBe(VALID_USER_ID);
+    expect(callArg.bookId.value).toBe(VALID_BOOK_ID);
+  });
+
+  it('should return 200 with { favorite: false } when toggled off', async () => {
+    toggleFavoriteExecute.mockResolvedValueOnce({ favorite: false });
+
+    const response = await fetch(`${BASE_URL}/api/books/${VALID_BOOK_ID}/favorite`, {
+      method: 'POST',
+      headers: { Cookie: `access_token=${VALID_TOKEN}` },
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { success: boolean; data: { favorite: boolean } };
+    expect(body.success).toBe(true);
+    expect(body.data.favorite).toBe(false);
+  });
+
+  it('should return 404 when the book does not exist', async () => {
+    toggleFavoriteExecute.mockRejectedValueOnce(new BookNotFoundError(VALID_BOOK_ID));
+
+    const response = await fetch(`${BASE_URL}/api/books/${VALID_BOOK_ID}/favorite`, {
+      method: 'POST',
+      headers: { Cookie: `access_token=${VALID_TOKEN}` },
+    });
+
+    expect(response.status).toBe(404);
+    const body = await response.json() as { success: boolean };
+    expect(body.success).toBe(false);
+  });
+
+  it('should return 400 when book id is not a valid UUID', async () => {
+    const response = await fetch(`${BASE_URL}/api/books/not-a-uuid/favorite`, {
+      method: 'POST',
+      headers: { Cookie: `access_token=${VALID_TOKEN}` },
+    });
+
+    // InvalidUUIDError is a DomainError → 400
+    expect(response.status).toBe(400);
+    const body = await response.json() as { success: boolean };
+    expect(body.success).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/books?favorites=true
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/books?favorites=true', () => {
+  let server: FastifyInstance;
+  let searchBooksExecute: ReturnType<typeof vi.fn>;
+
+  beforeAll(async () => {
+    searchBooksExecute = vi.fn().mockResolvedValue({
+      items: [],
+      pagination: { limit: 50, hasNextPage: false, nextCursor: null, totalCount: 0 },
+    });
+    const jwtService = makeJwtService();
+
+    server = await createServer(
+      {
+        ...makeNoopUseCases(),
+        searchBooksUseCase: { execute: searchBooksExecute },
+        sendBookByEmailUseCase: { execute: vi.fn().mockResolvedValue(undefined) },
+        jwtService,
+        logger: noopLogger,
+      },
+      { prefix: '/api', nodeEnv: 'test' },
+    );
+    await server.listen({ port: TEST_PORT + 1, host: '127.0.0.1' });
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it('should ignore favorites filter when no token is present', async () => {
+    searchBooksExecute.mockClear();
+
+    const response = await fetch(`${BASE_URL.replace(`:${TEST_PORT}`, `:${TEST_PORT + 1}`)}/api/books?favorites=true`);
+
+    expect(response.status).toBe(200);
+
+    // favoritesOf should be undefined since no token
+    const callArg = searchBooksExecute.mock.calls[0][0];
+    expect(callArg.favoritesOf).toBeUndefined();
+  });
+
+  it('should pass favoritesOf when token is valid and favorites=true', async () => {
+    searchBooksExecute.mockClear();
+
+    const response = await fetch(`${BASE_URL.replace(`:${TEST_PORT}`, `:${TEST_PORT + 1}`)}/api/books?favorites=true`, {
+      headers: { Cookie: `access_token=${VALID_TOKEN}` },
+    });
+
+    expect(response.status).toBe(200);
+
+    const callArg = searchBooksExecute.mock.calls[0][0];
+    expect(callArg.favoritesOf).toBeDefined();
+    expect(callArg.favoritesOf.value).toBe(VALID_USER_ID);
+  });
+
+  it('should NOT pass favoritesOf when favorites=false even with a valid token', async () => {
+    searchBooksExecute.mockClear();
+
+    const response = await fetch(`${BASE_URL.replace(`:${TEST_PORT}`, `:${TEST_PORT + 1}`)}/api/books?favorites=false`, {
+      headers: { Cookie: `access_token=${VALID_TOKEN}` },
+    });
+
+    expect(response.status).toBe(200);
+
+    const callArg = searchBooksExecute.mock.calls[0][0];
+    expect(callArg.favoritesOf).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/books/:id/send — RegisterDownloadUseCase integration
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/books/:id/send — download registration', () => {
+  let server: FastifyInstance;
+  let sendBookByEmailExecute: ReturnType<typeof vi.fn>;
+  let registerDownloadExecute: ReturnType<typeof vi.fn>;
+
+  beforeAll(async () => {
+    sendBookByEmailExecute = vi.fn().mockResolvedValue(undefined);
+    registerDownloadExecute = vi.fn().mockResolvedValue(undefined);
+    const jwtService = makeJwtService();
+
+    server = await createServer(
+      {
+        ...makeNoopUseCases(),
+        searchBooksUseCase: {
+          execute: vi.fn().mockResolvedValue({ items: [], pagination: { limit: 50, hasNextPage: false, nextCursor: null, totalCount: 0 } }),
+        },
+        sendBookByEmailUseCase: { execute: sendBookByEmailExecute },
+        registerDownloadUseCase: { execute: registerDownloadExecute },
+        jwtService,
+        logger: noopLogger,
+      },
+      { prefix: '/api', nodeEnv: 'test' },
+    );
+    await server.listen({ port: TEST_PORT + 2, host: '127.0.0.1' });
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  const baseUrl = `http://127.0.0.1:${TEST_PORT + 2}`;
+
+  it('should call RegisterDownloadUseCase when user is authenticated', async () => {
+    registerDownloadExecute.mockClear();
+
+    const response = await fetch(`${baseUrl}/api/books/${VALID_BOOK_ID}/send`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `access_token=${VALID_TOKEN}`,
+      },
+      body: JSON.stringify({ email: 'test@example.com' }),
+    });
+
+    expect(response.status).toBe(200);
+
+    // Give fire-and-forget a tick to complete
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(registerDownloadExecute).toHaveBeenCalledTimes(1);
+    const callArg = registerDownloadExecute.mock.calls[0][0];
+    expect(callArg.userId.value).toBe(VALID_USER_ID);
+    expect(callArg.bookId.value).toBe(VALID_BOOK_ID);
+  });
+
+  it('should NOT call RegisterDownloadUseCase when user is not authenticated', async () => {
+    registerDownloadExecute.mockClear();
+
+    const response = await fetch(`${baseUrl}/api/books/${VALID_BOOK_ID}/send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'test@example.com' }),
+    });
+
+    expect(response.status).toBe(200);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(registerDownloadExecute).not.toHaveBeenCalled();
+  });
+
+  it('should still return 200 even if RegisterDownloadUseCase fails', async () => {
+    registerDownloadExecute.mockRejectedValueOnce(new Error('DB error'));
+
+    const response = await fetch(`${baseUrl}/api/books/${VALID_BOOK_ID}/send`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `access_token=${VALID_TOKEN}`,
+      },
+      body: JSON.stringify({ email: 'test@example.com' }),
+    });
+
+    // Response should not be affected by download registration failure
+    expect(response.status).toBe(200);
+    const body = await response.json() as { success: boolean; data: { sent: boolean } };
+    expect(body.success).toBe(true);
+    expect(body.data.sent).toBe(true);
+  });
+});

--- a/apps/api/tests/e2e/setup.ts
+++ b/apps/api/tests/e2e/setup.ts
@@ -187,6 +187,8 @@ export async function createTestServer(db: TestDb, emailPort?: EmailPort): Promi
     refreshTokenUseCase: { execute: async () => ({ accessToken: '', refreshToken: '' }) },
     forgotPasswordUseCase: { execute: async () => undefined },
     resetPasswordUseCase: { execute: async () => undefined },
+    // HU-039: Favorite and download use cases not wired in the default test server
+    // (tests that need them create their own server via createServer directly)
     logger: noopLogger,
   }, { nodeEnv: 'test' });
 

--- a/apps/api/tests/integration/infrastructure/persistence/DrizzleDownloadRepository.integration.test.ts
+++ b/apps/api/tests/integration/infrastructure/persistence/DrizzleDownloadRepository.integration.test.ts
@@ -1,0 +1,163 @@
+/**
+ * DrizzleDownloadRepository Integration Tests
+ *
+ * Tests the DownloadRepository adapter against a real PostgreSQL database.
+ * Requires Docker containers to be running: docker-compose up -d
+ *
+ * Run with: npm run test:integration
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import pg from 'pg';
+import { DrizzleDownloadRepository } from '../../../../src/infrastructure/driven/persistence/DrizzleDownloadRepository.js';
+import { DrizzleUserRepository } from '../../../../src/infrastructure/driven/persistence/DrizzleUserRepository.js';
+import { User } from '../../../../src/domain/user/User.js';
+import { UserId } from '../../../../src/domain/user/value-objects/UserId.js';
+import { BookId } from '../../../../src/domain/book/value-objects/BookId.js';
+import { Download } from '../../../../src/domain/download/Download.js';
+import * as schema from '../../../../src/infrastructure/driven/persistence/drizzle/schema.js';
+
+const { Pool } = pg;
+const { users, userBookDownloads, books } = schema;
+
+/**
+ * Creates a minimal book row directly in DB (bypasses full BookRepository setup).
+ * Requires a valid typeId from seed data.
+ */
+async function insertTestBook(db: ReturnType<typeof drizzle>, bookId: string, typeId: string): Promise<void> {
+  await db.insert(books).values({
+    id: bookId,
+    title: `Test Book ${bookId.slice(0, 8)}`,
+    originalDescription: 'Test description',
+    description: 'Descripción de prueba',
+    language: 'en',
+    typeId,
+    format: 'pdf',
+    available: true,
+    normalizedTitle: `test book ${bookId.slice(0, 8)}`,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as typeof schema.books.$inferInsert);
+}
+
+describe('DrizzleDownloadRepository Integration', () => {
+  let pool: pg.Pool;
+  let db: ReturnType<typeof drizzle>;
+  let repository: DrizzleDownloadRepository;
+  let userRepository: DrizzleUserRepository;
+  let testUser: User;
+  let testTypeId: string;
+  let testBookId: BookId;
+
+  beforeAll(async () => {
+    const databaseUrl = process.env['DATABASE_URL'] ?? 'postgresql://library:library@localhost:5432/library';
+
+    pool = new Pool({ connectionString: databaseUrl, max: 5 });
+
+    const client = await pool.connect();
+    client.release();
+
+    db = drizzle(pool, { schema });
+    repository = new DrizzleDownloadRepository(db as any);
+    userRepository = new DrizzleUserRepository(db as any);
+
+    // Fetch a valid typeId from seed data (types table is seeded by init-db.sql)
+    const typeRecord = await (db as any).query.types.findFirst();
+    if (!typeRecord) {
+      throw new Error('No types found in database. Run init-db.sql first.');
+    }
+    testTypeId = typeRecord.id;
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    // Clean up in FK order
+    await db.delete(userBookDownloads);
+    await db.delete(books);
+    await db.delete(users);
+
+    // Create a test user
+    testUser = User.create({ email: 'download-user@example.com', passwordHash: 'hash' });
+    await userRepository.save(testUser);
+
+    // Create a test book directly
+    testBookId = BookId.generate();
+    await insertTestBook(db as any, testBookId.value, testTypeId);
+  });
+
+  describe('upsert', () => {
+    it('should create a new download record when none exists', async () => {
+      const userId = testUser.id as UserId;
+      const download = Download.create(userId, testBookId);
+
+      await repository.upsert(download);
+
+      // Verify the record was persisted
+      const row = await (db as any).query.userBookDownloads.findFirst({
+        where: (t: any, { and, eq }: any) =>
+          and(eq(t.userId, userId.value), eq(t.bookId, testBookId.value)),
+      });
+
+      expect(row).not.toBeNull();
+      expect(row.userId).toBe(userId.value);
+      expect(row.bookId).toBe(testBookId.value);
+      expect(row.downloadedAt).toBeInstanceOf(Date);
+    });
+
+    it('should update downloadedAt when the record already exists', async () => {
+      const userId = testUser.id as UserId;
+
+      // First download — use a fixed past date to detect the update
+      const pastDate = new Date('2020-01-01T00:00:00Z');
+      const firstDownload = Download.fromPersistence({
+        userId: userId.value,
+        bookId: testBookId.value,
+        downloadedAt: pastDate,
+      });
+      await repository.upsert(firstDownload);
+
+      // Capture the timestamp after first upsert
+      const rowAfterFirst = await (db as any).query.userBookDownloads.findFirst({
+        where: (t: any, { and, eq }: any) =>
+          and(eq(t.userId, userId.value), eq(t.bookId, testBookId.value)),
+      });
+      expect(rowAfterFirst.downloadedAt.getTime()).toBeCloseTo(pastDate.getTime(), -3);
+
+      // Small delay to ensure timestamps differ
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Second download — should update downloadedAt to now
+      const secondDownload = Download.create(userId, testBookId);
+      await repository.upsert(secondDownload);
+
+      const rowAfterSecond = await (db as any).query.userBookDownloads.findFirst({
+        where: (t: any, { and, eq }: any) =>
+          and(eq(t.userId, userId.value), eq(t.bookId, testBookId.value)),
+      });
+
+      expect(rowAfterSecond).not.toBeNull();
+      // downloadedAt should be updated (newer than the original pastDate)
+      expect(rowAfterSecond.downloadedAt.getTime()).toBeGreaterThan(pastDate.getTime());
+    });
+
+    it('should keep only one record per (userId, bookId) after multiple upserts', async () => {
+      const userId = testUser.id as UserId;
+
+      const download = Download.create(userId, testBookId);
+      await repository.upsert(download);
+      await repository.upsert(download);
+      await repository.upsert(download);
+
+      const rows = await (db as any).query.userBookDownloads.findMany({
+        where: (t: any, { and, eq }: any) =>
+          and(eq(t.userId, userId.value), eq(t.bookId, testBookId.value)),
+      });
+
+      expect(rows).toHaveLength(1);
+    });
+  });
+});

--- a/apps/api/tests/integration/infrastructure/persistence/DrizzleFavoriteRepository.integration.test.ts
+++ b/apps/api/tests/integration/infrastructure/persistence/DrizzleFavoriteRepository.integration.test.ts
@@ -1,0 +1,199 @@
+/**
+ * DrizzleFavoriteRepository Integration Tests
+ *
+ * Tests the FavoriteRepository adapter against a real PostgreSQL database.
+ * Requires Docker containers to be running: docker-compose up -d
+ *
+ * Run with: npm run test:integration
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import pg from 'pg';
+import { DrizzleFavoriteRepository } from '../../../../src/infrastructure/driven/persistence/DrizzleFavoriteRepository.js';
+import { DrizzleUserRepository } from '../../../../src/infrastructure/driven/persistence/DrizzleUserRepository.js';
+import { User } from '../../../../src/domain/user/User.js';
+import { UserId } from '../../../../src/domain/user/value-objects/UserId.js';
+import { BookId } from '../../../../src/domain/book/value-objects/BookId.js';
+import { Favorite } from '../../../../src/domain/favorite/Favorite.js';
+import * as schema from '../../../../src/infrastructure/driven/persistence/drizzle/schema.js';
+
+const { Pool } = pg;
+const { users, userBookFavorites, books } = schema;
+
+/**
+ * Creates a minimal book row directly in DB (bypasses full BookRepository setup).
+ * Requires a valid typeId from seed data.
+ */
+async function insertTestBook(db: ReturnType<typeof drizzle>, bookId: string, typeId: string): Promise<void> {
+  await db.insert(books).values({
+    id: bookId,
+    title: `Test Book ${bookId.slice(0, 8)}`,
+    originalDescription: 'Test description',
+    description: 'Descripción de prueba',
+    language: 'en',
+    typeId,
+    format: 'pdf',
+    available: true,
+    normalizedTitle: `test book ${bookId.slice(0, 8)}`,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as typeof schema.books.$inferInsert);
+}
+
+describe('DrizzleFavoriteRepository Integration', () => {
+  let pool: pg.Pool;
+  let db: ReturnType<typeof drizzle>;
+  let repository: DrizzleFavoriteRepository;
+  let userRepository: DrizzleUserRepository;
+  let testUser: User;
+  let testTypeId: string;
+
+  let bookId1: BookId;
+  let bookId2: BookId;
+
+  beforeAll(async () => {
+    const databaseUrl = process.env['DATABASE_URL'] ?? 'postgresql://library:library@localhost:5432/library';
+
+    pool = new Pool({ connectionString: databaseUrl, max: 5 });
+
+    const client = await pool.connect();
+    client.release();
+
+    db = drizzle(pool, { schema });
+    repository = new DrizzleFavoriteRepository(db as any);
+    userRepository = new DrizzleUserRepository(db as any);
+
+    // Fetch a valid typeId from seed data (types table is seeded by init-db.sql)
+    const typeRecord = await (db as any).query.types.findFirst();
+    if (!typeRecord) {
+      throw new Error('No types found in database. Run init-db.sql first.');
+    }
+    testTypeId = typeRecord.id;
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    // Clean up in FK order
+    await db.delete(userBookFavorites);
+    await db.delete(books);
+    await db.delete(users);
+
+    // Create a test user
+    testUser = User.create({ email: 'fav-user@example.com', passwordHash: 'hash' });
+    await userRepository.save(testUser);
+
+    // Create test books directly
+    bookId1 = BookId.generate();
+    bookId2 = BookId.generate();
+    await insertTestBook(db as any, bookId1.value, testTypeId);
+    await insertTestBook(db as any, bookId2.value, testTypeId);
+  });
+
+  describe('add', () => {
+    it('should persist a new favorite', async () => {
+      const userId = testUser.id as UserId;
+      const favorite = Favorite.create(userId, bookId1);
+
+      await repository.add(favorite);
+
+      const found = await repository.findByUserAndBook(userId, bookId1);
+      expect(found).not.toBeNull();
+      expect(found!.userId.value).toBe(userId.value);
+      expect(found!.bookId.value).toBe(bookId1.value);
+    });
+  });
+
+  describe('findByUserAndBook', () => {
+    it('should return a Favorite when found', async () => {
+      const userId = testUser.id as UserId;
+      const favorite = Favorite.create(userId, bookId1);
+      await repository.add(favorite);
+
+      const found = await repository.findByUserAndBook(userId, bookId1);
+
+      expect(found).not.toBeNull();
+      expect(found!.userId.value).toBe(userId.value);
+      expect(found!.bookId.value).toBe(bookId1.value);
+    });
+
+    it('should return null when the favorite does not exist', async () => {
+      const userId = testUser.id as UserId;
+      const nonExistentBookId = BookId.generate();
+
+      // Insert the non-existent book so FK is satisfied, but don't add favorite
+      await insertTestBook(db as any, nonExistentBookId.value, testTypeId);
+
+      const found = await repository.findByUserAndBook(userId, nonExistentBookId);
+      expect(found).toBeNull();
+    });
+
+    it('should return null when user has no favorites at all', async () => {
+      const userId = testUser.id as UserId;
+      const found = await repository.findByUserAndBook(userId, bookId1);
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove an existing favorite', async () => {
+      const userId = testUser.id as UserId;
+      const favorite = Favorite.create(userId, bookId1);
+      await repository.add(favorite);
+
+      await repository.remove(userId, bookId1);
+
+      const found = await repository.findByUserAndBook(userId, bookId1);
+      expect(found).toBeNull();
+    });
+
+    it('should not throw when removing a non-existent favorite', async () => {
+      const userId = testUser.id as UserId;
+      await expect(repository.remove(userId, bookId1)).resolves.not.toThrow();
+    });
+  });
+
+  describe('findAllByUser', () => {
+    it('should return all BookIds favorited by the user', async () => {
+      const userId = testUser.id as UserId;
+      await repository.add(Favorite.create(userId, bookId1));
+      await repository.add(Favorite.create(userId, bookId2));
+
+      const result = await repository.findAllByUser(userId);
+
+      expect(result).toHaveLength(2);
+      const resultValues = result.map((id) => id.value);
+      expect(resultValues).toContain(bookId1.value);
+      expect(resultValues).toContain(bookId2.value);
+    });
+
+    it('should return an empty array when the user has no favorites', async () => {
+      const userId = testUser.id as UserId;
+
+      const result = await repository.findAllByUser(userId);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should only return favorites for the requested user', async () => {
+      // Create a second user
+      const otherUser = User.create({ email: 'other-user@example.com', passwordHash: 'hash' });
+      await userRepository.save(otherUser);
+
+      const userId = testUser.id as UserId;
+      const otherUserId = otherUser.id as UserId;
+
+      // User 1 favorites book1, user 2 favorites book2
+      await repository.add(Favorite.create(userId, bookId1));
+      await repository.add(Favorite.create(otherUserId, bookId2));
+
+      const result = await repository.findAllByUser(userId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.value).toBe(bookId1.value);
+    });
+  });
+});

--- a/apps/api/tests/unit/application/use-cases/SearchBooksUseCase.test.ts
+++ b/apps/api/tests/unit/application/use-cases/SearchBooksUseCase.test.ts
@@ -461,7 +461,11 @@ describe('SearchBooksUseCase', () => {
       });
 
       vi.mocked(mockFavoriteRepository.findAllByUser).mockResolvedValue([favoriteBookId]);
-      mockBookRepository.search.mockResolvedValue(createSearchResult([book1, book2]));
+      mockBookRepository.search.mockImplementation((_criteria, _embedding, bookIds) => {
+        const ids = new Set((bookIds ?? []).map((id: { value: string }) => id.value));
+        const filtered = [book1, book2].filter((b) => ids.has(b.id));
+        return Promise.resolve(createSearchResult(filtered));
+      });
 
       const result = await useCaseWithFavorites.execute({ favoritesOf: userId });
 

--- a/apps/api/tests/unit/application/use-cases/SearchBooksUseCase.test.ts
+++ b/apps/api/tests/unit/application/use-cases/SearchBooksUseCase.test.ts
@@ -6,11 +6,14 @@ import {
 } from '../../../../src/application/use-cases/SearchBooksUseCase.js';
 import type { BookRepository, SearchBooksResult, BookWithScore } from '../../../../src/application/ports/BookRepository.js';
 import type { EmbeddingService } from '../../../../src/application/ports/EmbeddingService.js';
+import type { FavoriteRepository } from '../../../../src/domain/favorite/ports/FavoriteRepository.js';
 import { Book } from '../../../../src/domain/entities/Book.js';
 import { Author } from '../../../../src/domain/entities/Author.js';
 import { BookType } from '../../../../src/domain/entities/BookType.js';
 import { Category } from '../../../../src/domain/entities/Category.js';
 import { EmbeddingServiceUnavailableError } from '../../../../src/application/errors/ApplicationErrors.js';
+import { UserId } from '../../../../src/domain/user/value-objects/UserId.js';
+import { BookId } from '../../../../src/domain/book/value-objects/BookId.js';
 
 describe('SearchBooksUseCase', () => {
   // Test data
@@ -37,6 +40,8 @@ describe('SearchBooksUseCase', () => {
     generateEmbedding: ReturnType<typeof vi.fn>;
     isAvailable: ReturnType<typeof vi.fn>;
   };
+
+  let mockFavoriteRepository: FavoriteRepository;
 
   let useCase: SearchBooksUseCase;
 
@@ -105,6 +110,13 @@ describe('SearchBooksUseCase', () => {
     mockEmbeddingService = {
       generateEmbedding: vi.fn(),
       isAvailable: vi.fn(),
+    };
+
+    mockFavoriteRepository = {
+      findByUserAndBook: vi.fn(),
+      add: vi.fn(),
+      remove: vi.fn(),
+      findAllByUser: vi.fn(),
     };
 
     const deps: SearchBooksUseCaseDeps = {
@@ -431,6 +443,87 @@ describe('SearchBooksUseCase', () => {
       const result = await useCase.execute({});
 
       expect(result.items[0]?.description).toBe('A test book description');
+    });
+  });
+
+  describe('favoritesOf filter', () => {
+    const userId = UserId.fromPersistence('550e8400-e29b-41d4-a716-446655440099');
+
+    it('should return only favorited books when favoritesOf is provided', async () => {
+      const book1 = createTestBook({ id: '11111111-1111-1111-1111-111111111111', title: 'Favorite Book' });
+      const book2 = createTestBook({ id: '22222222-2222-2222-2222-222222222222', title: 'Other Book' });
+      const favoriteBookId = BookId.fromPersistence('11111111-1111-1111-1111-111111111111');
+
+      const useCaseWithFavorites = new SearchBooksUseCase({
+        bookRepository: mockBookRepository as unknown as BookRepository,
+        embeddingService: mockEmbeddingService as unknown as EmbeddingService,
+        favoriteRepository: mockFavoriteRepository,
+      });
+
+      vi.mocked(mockFavoriteRepository.findAllByUser).mockResolvedValue([favoriteBookId]);
+      mockBookRepository.search.mockResolvedValue(createSearchResult([book1, book2]));
+
+      const result = await useCaseWithFavorites.execute({ favoritesOf: userId });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.id).toBe('11111111-1111-1111-1111-111111111111');
+    });
+
+    it('should return empty list when user has no favorites', async () => {
+      const book1 = createTestBook({ id: '11111111-1111-1111-1111-111111111111' });
+
+      const useCaseWithFavorites = new SearchBooksUseCase({
+        bookRepository: mockBookRepository as unknown as BookRepository,
+        embeddingService: mockEmbeddingService as unknown as EmbeddingService,
+        favoriteRepository: mockFavoriteRepository,
+      });
+
+      vi.mocked(mockFavoriteRepository.findAllByUser).mockResolvedValue([]);
+      mockBookRepository.search.mockResolvedValue(createSearchResult([book1]));
+
+      const result = await useCaseWithFavorites.execute({ favoritesOf: userId });
+
+      expect(result.items).toHaveLength(0);
+      expect(result.pagination.totalCount).toBe(0);
+    });
+
+    it('should not call favoriteRepository when favoritesOf is not provided', async () => {
+      const useCaseWithFavorites = new SearchBooksUseCase({
+        bookRepository: mockBookRepository as unknown as BookRepository,
+        embeddingService: mockEmbeddingService as unknown as EmbeddingService,
+        favoriteRepository: mockFavoriteRepository,
+      });
+
+      mockBookRepository.search.mockResolvedValue(createSearchResult([]));
+
+      await useCaseWithFavorites.execute({});
+
+      expect(mockFavoriteRepository.findAllByUser).not.toHaveBeenCalled();
+    });
+
+    it('should preserve normal behavior when favoritesOf is undefined', async () => {
+      const book = createTestBook({ id: '11111111-1111-1111-1111-111111111111' });
+      mockBookRepository.search.mockResolvedValue(createSearchResult([book]));
+
+      const result = await useCase.execute({});
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.id).toBe('11111111-1111-1111-1111-111111111111');
+    });
+
+    it('should call findAllByUser with the correct userId', async () => {
+      const useCaseWithFavorites = new SearchBooksUseCase({
+        bookRepository: mockBookRepository as unknown as BookRepository,
+        embeddingService: mockEmbeddingService as unknown as EmbeddingService,
+        favoriteRepository: mockFavoriteRepository,
+      });
+
+      vi.mocked(mockFavoriteRepository.findAllByUser).mockResolvedValue([]);
+      mockBookRepository.search.mockResolvedValue(createSearchResult([]));
+
+      await useCaseWithFavorites.execute({ favoritesOf: userId });
+
+      expect(mockFavoriteRepository.findAllByUser).toHaveBeenCalledWith(userId);
     });
   });
 });

--- a/apps/api/tests/unit/application/use-cases/download/RegisterDownloadUseCase.test.ts
+++ b/apps/api/tests/unit/application/use-cases/download/RegisterDownloadUseCase.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit Tests: RegisterDownloadUseCase
+ *
+ * Tests for the use case that registers a book download event.
+ * HU-039: Downloads feature.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RegisterDownloadUseCase } from '../../../../../src/application/use-cases/download/RegisterDownloadUseCase.js';
+import { UserId } from '../../../../../src/domain/user/value-objects/UserId.js';
+import { BookId } from '../../../../../src/domain/book/value-objects/BookId.js';
+import { Download } from '../../../../../src/domain/download/Download.js';
+import type { DownloadRepository } from '../../../../../src/domain/download/ports/DownloadRepository.js';
+
+describe('RegisterDownloadUseCase', () => {
+  const userId = UserId.fromPersistence('550e8400-e29b-41d4-a716-446655440001');
+  const bookId = BookId.fromPersistence('550e8400-e29b-41d4-a716-446655440002');
+
+  let mockDownloadRepository: DownloadRepository;
+  let useCase: RegisterDownloadUseCase;
+
+  beforeEach(() => {
+    mockDownloadRepository = {
+      upsert: vi.fn(),
+    };
+
+    useCase = new RegisterDownloadUseCase({ downloadRepository: mockDownloadRepository });
+  });
+
+  describe('execute — happy path', () => {
+    it('should call upsert with a Download entity', async () => {
+      vi.mocked(mockDownloadRepository.upsert).mockResolvedValue(undefined);
+
+      await useCase.execute({ userId, bookId });
+
+      expect(mockDownloadRepository.upsert).toHaveBeenCalledTimes(1);
+      const passedDownload = vi.mocked(mockDownloadRepository.upsert).mock.calls[0]?.[0];
+      expect(passedDownload).toBeInstanceOf(Download);
+      expect(passedDownload?.userId.equals(userId)).toBe(true);
+      expect(passedDownload?.bookId.equals(bookId)).toBe(true);
+    });
+
+    it('should resolve without returning a value', async () => {
+      vi.mocked(mockDownloadRepository.upsert).mockResolvedValue(undefined);
+
+      const result = await useCase.execute({ userId, bookId });
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('execute — error propagation', () => {
+    it('should propagate errors thrown by the repository', async () => {
+      const repositoryError = new Error('Database connection failed');
+      vi.mocked(mockDownloadRepository.upsert).mockRejectedValue(repositoryError);
+
+      await expect(useCase.execute({ userId, bookId })).rejects.toThrow('Database connection failed');
+    });
+  });
+});

--- a/apps/api/tests/unit/application/use-cases/favorite/ToggleFavoriteUseCase.test.ts
+++ b/apps/api/tests/unit/application/use-cases/favorite/ToggleFavoriteUseCase.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Unit Tests: ToggleFavoriteUseCase
+ *
+ * Tests for the use case that toggles a book as favorite for a user.
+ * HU-039: Favorites feature.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ToggleFavoriteUseCase } from '../../../../../src/application/use-cases/favorite/ToggleFavoriteUseCase.js';
+import { UserId } from '../../../../../src/domain/user/value-objects/UserId.js';
+import { BookId } from '../../../../../src/domain/book/value-objects/BookId.js';
+import { Favorite } from '../../../../../src/domain/favorite/Favorite.js';
+import type { FavoriteRepository } from '../../../../../src/domain/favorite/ports/FavoriteRepository.js';
+
+describe('ToggleFavoriteUseCase', () => {
+  const userId = UserId.fromPersistence('550e8400-e29b-41d4-a716-446655440001');
+  const bookId = BookId.fromPersistence('550e8400-e29b-41d4-a716-446655440002');
+
+  let mockFavoriteRepository: FavoriteRepository;
+  let useCase: ToggleFavoriteUseCase;
+
+  beforeEach(() => {
+    mockFavoriteRepository = {
+      findByUserAndBook: vi.fn(),
+      add: vi.fn(),
+      remove: vi.fn(),
+      findAllByUser: vi.fn(),
+    };
+
+    useCase = new ToggleFavoriteUseCase({ favoriteRepository: mockFavoriteRepository });
+  });
+
+  describe('execute — book not yet favorited', () => {
+    it('should add the favorite and return { favorite: true }', async () => {
+      vi.mocked(mockFavoriteRepository.findByUserAndBook).mockResolvedValue(null);
+      vi.mocked(mockFavoriteRepository.add).mockResolvedValue(undefined);
+
+      const result = await useCase.execute({ userId, bookId });
+
+      expect(result).toEqual({ favorite: true });
+    });
+
+    it('should call add with a Favorite entity', async () => {
+      vi.mocked(mockFavoriteRepository.findByUserAndBook).mockResolvedValue(null);
+      vi.mocked(mockFavoriteRepository.add).mockResolvedValue(undefined);
+
+      await useCase.execute({ userId, bookId });
+
+      expect(mockFavoriteRepository.add).toHaveBeenCalledTimes(1);
+      const addedFavorite = vi.mocked(mockFavoriteRepository.add).mock.calls[0]?.[0];
+      expect(addedFavorite).toBeInstanceOf(Favorite);
+      expect(addedFavorite?.userId.equals(userId)).toBe(true);
+      expect(addedFavorite?.bookId.equals(bookId)).toBe(true);
+    });
+
+    it('should not call remove when the book is not favorited', async () => {
+      vi.mocked(mockFavoriteRepository.findByUserAndBook).mockResolvedValue(null);
+      vi.mocked(mockFavoriteRepository.add).mockResolvedValue(undefined);
+
+      await useCase.execute({ userId, bookId });
+
+      expect(mockFavoriteRepository.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('execute — book already favorited', () => {
+    it('should remove the favorite and return { favorite: false }', async () => {
+      const existingFavorite = Favorite.create(userId, bookId);
+      vi.mocked(mockFavoriteRepository.findByUserAndBook).mockResolvedValue(existingFavorite);
+      vi.mocked(mockFavoriteRepository.remove).mockResolvedValue(undefined);
+
+      const result = await useCase.execute({ userId, bookId });
+
+      expect(result).toEqual({ favorite: false });
+    });
+
+    it('should call remove with the correct userId and bookId', async () => {
+      const existingFavorite = Favorite.create(userId, bookId);
+      vi.mocked(mockFavoriteRepository.findByUserAndBook).mockResolvedValue(existingFavorite);
+      vi.mocked(mockFavoriteRepository.remove).mockResolvedValue(undefined);
+
+      await useCase.execute({ userId, bookId });
+
+      expect(mockFavoriteRepository.remove).toHaveBeenCalledWith(userId, bookId);
+    });
+
+    it('should not call add when the book is already favorited', async () => {
+      const existingFavorite = Favorite.create(userId, bookId);
+      vi.mocked(mockFavoriteRepository.findByUserAndBook).mockResolvedValue(existingFavorite);
+      vi.mocked(mockFavoriteRepository.remove).mockResolvedValue(undefined);
+
+      await useCase.execute({ userId, bookId });
+
+      expect(mockFavoriteRepository.add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('execute — lookup', () => {
+    it('should call findByUserAndBook with the correct userId and bookId', async () => {
+      vi.mocked(mockFavoriteRepository.findByUserAndBook).mockResolvedValue(null);
+      vi.mocked(mockFavoriteRepository.add).mockResolvedValue(undefined);
+
+      await useCase.execute({ userId, bookId });
+
+      expect(mockFavoriteRepository.findByUserAndBook).toHaveBeenCalledWith(userId, bookId);
+    });
+  });
+});

--- a/apps/api/tests/unit/domain/book/BookId.test.ts
+++ b/apps/api/tests/unit/domain/book/BookId.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { BookId } from '../../../../src/domain/book/value-objects/BookId.js';
+import { InvalidUUIDError } from '../../../../src/domain/errors/DomainErrors.js';
+
+const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
+
+describe('BookId', () => {
+  describe('create', () => {
+    it('should create a BookId from a valid UUID', () => {
+      const bookId = BookId.create(VALID_UUID);
+      expect(bookId.value).toBe(VALID_UUID);
+    });
+
+    it('should trim whitespace before validation', () => {
+      const bookId = BookId.create(`  ${VALID_UUID}  `);
+      expect(bookId.value).toBe(VALID_UUID);
+    });
+
+    it('should throw InvalidUUIDError for an empty string', () => {
+      expect(() => BookId.create('')).toThrow(InvalidUUIDError);
+    });
+
+    it('should throw InvalidUUIDError for whitespace-only string', () => {
+      expect(() => BookId.create('   ')).toThrow(InvalidUUIDError);
+    });
+
+    it('should throw InvalidUUIDError for a non-UUID string', () => {
+      expect(() => BookId.create('not-a-uuid')).toThrow(InvalidUUIDError);
+    });
+  });
+
+  describe('generate', () => {
+    it('should generate a valid UUID', () => {
+      const bookId = BookId.generate();
+      expect(bookId.value).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
+    });
+
+    it('should generate unique ids', () => {
+      const id1 = BookId.generate();
+      const id2 = BookId.generate();
+      expect(id1.value).not.toBe(id2.value);
+    });
+  });
+
+  describe('fromPersistence', () => {
+    it('should create a BookId from a trusted value without validation', () => {
+      const bookId = BookId.fromPersistence(VALID_UUID);
+      expect(bookId.value).toBe(VALID_UUID);
+    });
+  });
+
+  describe('equals', () => {
+    it('should return true for two BookIds with the same value', () => {
+      const id1 = BookId.fromPersistence(VALID_UUID);
+      const id2 = BookId.fromPersistence(VALID_UUID);
+      expect(id1.equals(id2)).toBe(true);
+    });
+
+    it('should return false for two BookIds with different values', () => {
+      const id1 = BookId.generate();
+      const id2 = BookId.generate();
+      expect(id1.equals(id2)).toBe(false);
+    });
+  });
+
+  describe('immutability', () => {
+    it('should be frozen', () => {
+      const bookId = BookId.create(VALID_UUID);
+      expect(Object.isFrozen(bookId)).toBe(true);
+    });
+  });
+
+  describe('toString', () => {
+    it('should return the UUID string', () => {
+      const bookId = BookId.fromPersistence(VALID_UUID);
+      expect(bookId.toString()).toBe(VALID_UUID);
+    });
+  });
+});

--- a/apps/api/tests/unit/domain/download/Download.test.ts
+++ b/apps/api/tests/unit/domain/download/Download.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { Download } from '../../../../src/domain/download/Download.js';
+import { UserId } from '../../../../src/domain/user/value-objects/UserId.js';
+import { BookId } from '../../../../src/domain/book/value-objects/BookId.js';
+
+const USER_UUID = '550e8400-e29b-41d4-a716-446655440001';
+const BOOK_UUID = '550e8400-e29b-41d4-a716-446655440002';
+
+describe('Download', () => {
+  describe('create', () => {
+    it('should create a Download with the given userId and bookId', () => {
+      const userId = UserId.fromPersistence(USER_UUID);
+      const bookId = BookId.fromPersistence(BOOK_UUID);
+
+      const download = Download.create(userId, bookId);
+
+      expect(download.userId.value).toBe(USER_UUID);
+      expect(download.bookId.value).toBe(BOOK_UUID);
+    });
+
+    it('should set downloadedAt to current date', () => {
+      const before = new Date();
+      const download = Download.create(
+        UserId.fromPersistence(USER_UUID),
+        BookId.fromPersistence(BOOK_UUID),
+      );
+      const after = new Date();
+
+      expect(download.downloadedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(download.downloadedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+  });
+
+  describe('fromPersistence', () => {
+    it('should reconstruct a Download from persistence data', () => {
+      const downloadedAt = new Date('2024-06-01T12:00:00Z');
+
+      const download = Download.fromPersistence({
+        userId: USER_UUID,
+        bookId: BOOK_UUID,
+        downloadedAt,
+      });
+
+      expect(download.userId.value).toBe(USER_UUID);
+      expect(download.bookId.value).toBe(BOOK_UUID);
+      expect(download.downloadedAt).toBe(downloadedAt);
+    });
+  });
+
+  describe('immutability', () => {
+    it('should be frozen', () => {
+      const download = Download.create(
+        UserId.fromPersistence(USER_UUID),
+        BookId.fromPersistence(BOOK_UUID),
+      );
+      expect(Object.isFrozen(download)).toBe(true);
+    });
+
+    it('should not allow reassigning bookId', () => {
+      const download = Download.create(
+        UserId.fromPersistence(USER_UUID),
+        BookId.fromPersistence(BOOK_UUID),
+      );
+      expect(() => {
+        // @ts-expect-error testing immutability
+        download.bookId = BookId.generate();
+      }).toThrow();
+    });
+  });
+
+  describe('equals', () => {
+    it('should return true for two Downloads with the same userId and bookId', () => {
+      const d1 = Download.fromPersistence({ userId: USER_UUID, bookId: BOOK_UUID, downloadedAt: new Date() });
+      const d2 = Download.fromPersistence({ userId: USER_UUID, bookId: BOOK_UUID, downloadedAt: new Date() });
+      expect(d1.equals(d2)).toBe(true);
+    });
+
+    it('should return false when userId differs', () => {
+      const otherUser = '770e8400-e29b-41d4-a716-446655440099';
+      const d1 = Download.fromPersistence({ userId: USER_UUID, bookId: BOOK_UUID, downloadedAt: new Date() });
+      const d2 = Download.fromPersistence({ userId: otherUser, bookId: BOOK_UUID, downloadedAt: new Date() });
+      expect(d1.equals(d2)).toBe(false);
+    });
+  });
+});

--- a/apps/api/tests/unit/domain/favorite/Favorite.test.ts
+++ b/apps/api/tests/unit/domain/favorite/Favorite.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { Favorite } from '../../../../src/domain/favorite/Favorite.js';
+import { UserId } from '../../../../src/domain/user/value-objects/UserId.js';
+import { BookId } from '../../../../src/domain/book/value-objects/BookId.js';
+
+const USER_UUID = '550e8400-e29b-41d4-a716-446655440001';
+const BOOK_UUID = '550e8400-e29b-41d4-a716-446655440002';
+
+describe('Favorite', () => {
+  describe('create', () => {
+    it('should create a Favorite with the given userId and bookId', () => {
+      const userId = UserId.fromPersistence(USER_UUID);
+      const bookId = BookId.fromPersistence(BOOK_UUID);
+
+      const favorite = Favorite.create(userId, bookId);
+
+      expect(favorite.userId.value).toBe(USER_UUID);
+      expect(favorite.bookId.value).toBe(BOOK_UUID);
+    });
+
+    it('should set createdAt to current date', () => {
+      const before = new Date();
+      const favorite = Favorite.create(
+        UserId.fromPersistence(USER_UUID),
+        BookId.fromPersistence(BOOK_UUID),
+      );
+      const after = new Date();
+
+      expect(favorite.createdAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(favorite.createdAt.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+  });
+
+  describe('fromPersistence', () => {
+    it('should reconstruct a Favorite from persistence data', () => {
+      const createdAt = new Date('2024-06-01T12:00:00Z');
+
+      const favorite = Favorite.fromPersistence({
+        userId: USER_UUID,
+        bookId: BOOK_UUID,
+        createdAt,
+      });
+
+      expect(favorite.userId.value).toBe(USER_UUID);
+      expect(favorite.bookId.value).toBe(BOOK_UUID);
+      expect(favorite.createdAt).toBe(createdAt);
+    });
+  });
+
+  describe('immutability', () => {
+    it('should be frozen', () => {
+      const favorite = Favorite.create(
+        UserId.fromPersistence(USER_UUID),
+        BookId.fromPersistence(BOOK_UUID),
+      );
+      expect(Object.isFrozen(favorite)).toBe(true);
+    });
+
+    it('should not allow reassigning userId', () => {
+      const favorite = Favorite.create(
+        UserId.fromPersistence(USER_UUID),
+        BookId.fromPersistence(BOOK_UUID),
+      );
+      expect(() => {
+        // @ts-expect-error testing immutability
+        favorite.userId = UserId.generate();
+      }).toThrow();
+    });
+  });
+
+  describe('equals', () => {
+    it('should return true for two Favorites with the same userId and bookId', () => {
+      const f1 = Favorite.fromPersistence({ userId: USER_UUID, bookId: BOOK_UUID, createdAt: new Date() });
+      const f2 = Favorite.fromPersistence({ userId: USER_UUID, bookId: BOOK_UUID, createdAt: new Date() });
+      expect(f1.equals(f2)).toBe(true);
+    });
+
+    it('should return false when bookId differs', () => {
+      const otherBook = '660e8400-e29b-41d4-a716-446655440099';
+      const f1 = Favorite.fromPersistence({ userId: USER_UUID, bookId: BOOK_UUID, createdAt: new Date() });
+      const f2 = Favorite.fromPersistence({ userId: USER_UUID, bookId: otherBook, createdAt: new Date() });
+      expect(f1.equals(f2)).toBe(false);
+    });
+
+    it('should return false when userId differs', () => {
+      const otherUser = '770e8400-e29b-41d4-a716-446655440099';
+      const f1 = Favorite.fromPersistence({ userId: USER_UUID, bookId: BOOK_UUID, createdAt: new Date() });
+      const f2 = Favorite.fromPersistence({ userId: otherUser, bookId: BOOK_UUID, createdAt: new Date() });
+      expect(f1.equals(f2)).toBe(false);
+    });
+  });
+});

--- a/apps/api/tests/unit/infrastructure/driver/http/controllers/SearchBooksController.test.ts
+++ b/apps/api/tests/unit/infrastructure/driver/http/controllers/SearchBooksController.test.ts
@@ -62,6 +62,7 @@ const mockSearchOutput: SearchBooksOutput = {
       format: 'pdf',
       description: 'A Handbook of Agile Software Craftsmanship',
       similarityScore: null,
+      favorite: false,
     },
   ],
   pagination: {

--- a/apps/web-client/src/app/books/services/favorite.service.ts
+++ b/apps/web-client/src/app/books/services/favorite.service.ts
@@ -1,0 +1,34 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ApiService } from '../../core/services/api.service.js';
+
+/**
+ * Response from the favorite toggle endpoint
+ */
+export interface FavoriteToggleResponse {
+  favorite: boolean;
+}
+
+/**
+ * FavoriteService - Handles book favorite toggle operations
+ *
+ * Calls POST /api/books/:id/favorite to toggle the favorite state.
+ * Auth is handled automatically via HttpOnly cookie sent by the browser.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class FavoriteService {
+  private readonly api = inject(ApiService);
+
+  /**
+   * Toggle the favorite state for a book
+   *
+   * @param bookId - The ID of the book to toggle
+   * @returns Observable of FavoriteToggleResponse with updated favorite state
+   */
+  toggle(bookId: string): Observable<FavoriteToggleResponse> {
+    return this.api.post<FavoriteToggleResponse>(`/books/${bookId}/favorite`, {});
+  }
+}

--- a/apps/web-client/src/app/catalog/components/filters/filter-panel/filter-panel.component.ts
+++ b/apps/web-client/src/app/catalog/components/filters/filter-panel/filter-panel.component.ts
@@ -7,6 +7,7 @@ import {
   effect,
   ChangeDetectionStrategy,
 } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 
 import { TextFilterInputComponent } from '../text-filter-input/index.js';
 import { SearchableSelectComponent } from '../searchable-select/index.js';
@@ -28,6 +29,7 @@ interface FilterState {
   categories: string[];
   levels: string[];
   text: string;
+  favorites: boolean;
 }
 
 /**
@@ -41,6 +43,7 @@ const DEFAULT_FILTERS: FilterState = {
   categories: [],
   levels: [],
   text: '',
+  favorites: false,
 };
 
 /**
@@ -63,6 +66,7 @@ const DEFAULT_FILTERS: FilterState = {
     SearchableSelectComponent,
     MultiSelectChipsComponent,
     SemanticSearchComponent,
+    FormsModule,
   ],
   template: `
     <div
@@ -186,6 +190,30 @@ const DEFAULT_FILTERS: FilterState = {
             />
           </div>
         </section>
+
+        @if (isAuthenticated()) {
+          <div class="filter-panel__divider"></div>
+
+          <!-- Favorites section -->
+          <section class="filter-section">
+            <h3 class="filter-section__title">Mi biblioteca</h3>
+
+            <label
+              class="favorites-checkbox-label"
+              data-testid="favorites-filter"
+            >
+              <input
+                type="checkbox"
+                class="favorites-checkbox"
+                [checked]="currentFilters().favorites"
+                [disabled]="disabled()"
+                (change)="onFavoritesChange($event)"
+              />
+              <span class="material-symbols-outlined favorites-icon">favorite</span>
+              <span>Mis favoritos</span>
+            </label>
+          </section>
+        }
       </div>
     </div>
   `,
@@ -296,6 +324,37 @@ const DEFAULT_FILTERS: FilterState = {
         letter-spacing: 0.05em;
         color: rgb(148 163 184);
       }
+
+      .favorites-checkbox-label {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        cursor: pointer;
+        font-size: 0.875rem;
+        color: rgb(148 163 184);
+        user-select: none;
+
+        &:has(input:disabled) {
+          opacity: 0.4;
+          cursor: not-allowed;
+        }
+      }
+
+      .favorites-checkbox {
+        accent-color: #17a1cf;
+        width: 1rem;
+        height: 1rem;
+        cursor: pointer;
+      }
+
+      .favorites-icon {
+        font-size: 1rem;
+        color: #e11d48;
+      }
+
+      [data-theme='light'] .favorites-checkbox-label {
+        color: rgb(100 116 139);
+      }
     `,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -314,6 +373,7 @@ export class FilterPanelComponent {
   // General state inputs
   readonly disabled = input<boolean>(false);
   readonly value = input<SearchFilters | null>(null);
+  readonly isAuthenticated = input<boolean>(false);
 
   // Outputs
   readonly filtersChange = output<SearchFilters>();
@@ -335,7 +395,8 @@ export class FilterPanelComponent {
       filters.type !== '' ||
       filters.categories.length > 0 ||
       filters.levels.length > 0 ||
-      filters.text !== ''
+      filters.text !== '' ||
+      filters.favorites
     );
   });
 
@@ -350,6 +411,7 @@ export class FilterPanelComponent {
           ...externalValue,
           categories: externalValue.categories ?? [],
           levels: externalValue.levels ?? [],
+          favorites: externalValue.favorites ?? false,
         });
         this.previousType = externalValue.type ?? '';
       }
@@ -394,6 +456,11 @@ export class FilterPanelComponent {
     this.updateFilters({ text });
   }
 
+  onFavoritesChange(event: Event): void {
+    const checked = (event.target as HTMLInputElement).checked;
+    this.updateFilters({ favorites: checked });
+  }
+
   clearFilters(): void {
     this.currentFilters.set({ ...DEFAULT_FILTERS });
     this.previousType = '';
@@ -424,6 +491,7 @@ export class FilterPanelComponent {
     if (state.categories.length > 0) filters.categories = state.categories;
     if (state.levels.length > 0) filters.levels = state.levels;
     if (state.text) filters.text = state.text;
+    if (state.favorites) filters.favorites = true;
 
     return filters;
   }

--- a/apps/web-client/src/app/catalog/components/table/book-table/book-table.component.ts
+++ b/apps/web-client/src/app/catalog/components/table/book-table/book-table.component.ts
@@ -1,4 +1,13 @@
-import { ChangeDetectionStrategy, Component, input, output, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  output,
+  signal,
+  viewChild,
+} from '@angular/core';
 import { CategoryChipsComponent } from '../../data-display/category-chips/category-chips.component.js';
 import { LevelBadgeComponent } from '../../data-display/level-badge/level-badge.component.js';
 import { LanguageFlagComponent } from '../../data-display/language-flag/language-flag.component.js';
@@ -6,6 +15,8 @@ import { EmptyStateComponent } from '../empty-state/empty-state.component.js';
 import { LoadingOverlayComponent } from '../loading-overlay/loading-overlay.component.js';
 import { BookDescriptionDialogComponent } from '../../dialogs/book-description-dialog/book-description-dialog.component.js';
 import { Book } from '../../../../core/models/index.js';
+import { AuthService } from '../../../../auth/auth.service.js';
+import { FavoriteService } from '../../../../books/services/favorite.service.js';
 
 @Component({
   selector: 'app-book-table',
@@ -35,7 +46,9 @@ import { Book } from '../../../../core/models/index.js';
                   <th>Nivel</th>
                   <th>Formato</th>
                   <th>Descripción</th>
-                  <th class="text-right">Acciones</th>
+                  @if (isAuthenticated()) {
+                    <th class="text-right">Acciones</th>
+                  }
                 </tr>
               </thead>
               <tbody>
@@ -88,17 +101,31 @@ import { Book } from '../../../../core/models/index.js';
                         <span class="description-text">-</span>
                       }
                     </td>
-                    <td class="actions-column text-right">
-                      <button
-                        class="action-button"
-                        type="button"
-                        aria-label="Send to Kindle"
-                        title="Enviar a Kindle"
-                        (click)="onSendToKindle($event, book)"
-                      >
-                        <span class="material-symbols-outlined">send_to_mobile</span>
-                      </button>
-                    </td>
+                    @if (isAuthenticated()) {
+                      <td class="actions-column text-right">
+                        <button
+                          class="action-button"
+                          type="button"
+                          aria-label="Send to Kindle"
+                          title="Enviar a Kindle"
+                          (click)="onSendToKindle($event, book)"
+                        >
+                          <span class="material-symbols-outlined">send_to_mobile</span>
+                        </button>
+                        <button
+                          class="action-button"
+                          type="button"
+                          [attr.aria-label]="getFavoriteAriaLabel(book)"
+                          [title]="getFavoriteAriaLabel(book)"
+                          [class.favorite-active]="getEffectiveFavorite(book)"
+                          (click)="onToggleFavorite($event, book)"
+                        >
+                          <span class="material-symbols-outlined">{{
+                            getEffectiveFavorite(book) ? 'favorite' : 'favorite_border'
+                          }}</span>
+                        </button>
+                      </td>
+                    }
                   </tr>
                 }
               </tbody>
@@ -261,7 +288,7 @@ import { Book } from '../../../../core/models/index.js';
     }
 
     .actions-column {
-      width: 80px;
+      width: 120px;
     }
 
     .isbn-column {
@@ -312,18 +339,32 @@ import { Book } from '../../../../core/models/index.js';
         height: 1.25rem;
       }
     }
+
+    .action-button.favorite-active {
+      color: #e11d48; /* rose-600 — filled heart color */
+    }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BookTableComponent {
+  private readonly authService = inject(AuthService);
+  private readonly favoriteService = inject(FavoriteService);
+
   readonly books = input<Book[]>([]);
   readonly loading = input<boolean>(false);
   readonly emptyStateType = input<'empty' | 'no-results' | 'initial'>('empty');
 
   readonly rowClick = output<Book>();
   readonly sendToKindle = output<Book>();
+  readonly favoriteToggle = output<{ book: Book; favorite: boolean }>();
 
   readonly descriptionDialog = viewChild.required(BookDescriptionDialogComponent);
+
+  /** Derived signal: true when a user is logged in */
+  readonly isAuthenticated = computed(() => this.authService.currentUser() !== null);
+
+  /** Local map to track optimistic favorite state (bookId → favorite) */
+  private readonly favoriteOverrides = signal<Record<string, boolean>>({});
 
   onRowClick(book: Book): void {
     this.rowClick.emit(book);
@@ -337,6 +378,48 @@ export class BookTableComponent {
   onShowDescription(event: Event, book: Book): void {
     event.stopPropagation();
     this.descriptionDialog().open(book.title, book.description);
+  }
+
+  onToggleFavorite(event: Event, book: Book): void {
+    event.stopPropagation();
+
+    // Optimistic update
+    const currentFavorite = this.getEffectiveFavorite(book);
+    const newFavorite = !currentFavorite;
+    this.favoriteOverrides.update((overrides) => ({ ...overrides, [book.id]: newFavorite }));
+
+    this.favoriteService.toggle(book.id).subscribe({
+      next: (response) => {
+        this.favoriteOverrides.update((overrides) => ({
+          ...overrides,
+          [book.id]: response.favorite,
+        }));
+        this.favoriteToggle.emit({ book, favorite: response.favorite });
+      },
+      error: () => {
+        // Revert optimistic update on error
+        this.favoriteOverrides.update((overrides) => ({
+          ...overrides,
+          [book.id]: currentFavorite,
+        }));
+      },
+    });
+  }
+
+  getFavoriteAriaLabel(book: Book): string {
+    return this.getEffectiveFavorite(book) ? 'Quitar de favoritos' : 'Añadir a favoritos';
+  }
+
+  /**
+   * Get the effective favorite state for a book,
+   * preferring the local optimistic override over the server value.
+   */
+  getEffectiveFavorite(book: Book): boolean {
+    const overrides = this.favoriteOverrides();
+    if (book.id in overrides) {
+      return overrides[book.id];
+    }
+    return book.favorite ?? false;
   }
 
   // Helper methods to extract names from Author/Category objects

--- a/apps/web-client/src/app/catalog/pages/book-list/book-list-page.component.ts
+++ b/apps/web-client/src/app/catalog/pages/book-list/book-list-page.component.ts
@@ -17,6 +17,7 @@ import { PaginatorComponent } from '../../components/table/paginator/index.js';
 import { SendToKindleDialogComponent } from '../../components/dialogs/index.js';
 import { BookSearchStore } from '../../../core/services/book-search.store.js';
 import { DialogService } from '../../../core/services/dialog.service.js';
+import { AuthService } from '../../../auth/auth.service.js';
 import {
   Book,
   BookType,
@@ -72,6 +73,7 @@ import {
           [typesLoading]="store.typesLoading()"
           [categoriesLoading]="store.categoriesLoading()"
           [levelsLoading]="store.levelsLoading()"
+          [isAuthenticated]="isAuthenticated()"
           (filtersChange)="onFiltersChange($event)"
           (typeChange)="onTypeChange($event)"
         />
@@ -558,7 +560,11 @@ import {
 export class BookListPageComponent implements OnInit {
   readonly store = inject(BookSearchStore);
   private readonly dialogService = inject(DialogService);
+  private readonly authService = inject(AuthService);
   private readonly breakpointObserver = inject(BreakpointObserver);
+
+  /** True when a user is logged in */
+  readonly isAuthenticated = computed(() => this.authService.currentUser() !== null);
 
   // Mobile state
   readonly isMobileDrawerOpen = signal(false);
@@ -591,6 +597,7 @@ export class BookListPageComponent implements OnInit {
     if (filters.categories && filters.categories.length > 0) count++;
     if (filters.levels && filters.levels.length > 0) count++;
     if (filters.text) count++;
+    if (filters.favorites) count++;
 
     return count;
   });

--- a/apps/web-client/src/app/core/models/index.ts
+++ b/apps/web-client/src/app/core/models/index.ts
@@ -106,6 +106,8 @@ export interface Book {
   language: string;
   available: boolean;
   similarityScore: number | null;
+  /** Favorite state — only present when the user is authenticated */
+  favorite?: boolean;
 }
 
 /**
@@ -141,6 +143,8 @@ export interface SearchFilters {
   categories?: string[];
   levels?: string[];
   text?: string;
+  /** Filter by user favorites — only effective when authenticated */
+  favorites?: boolean;
 }
 
 /**

--- a/apps/web-client/src/app/core/services/book.service.ts
+++ b/apps/web-client/src/app/core/services/book.service.ts
@@ -124,6 +124,10 @@ export class BookService {
       params['levels'] = filters.levels;
     }
 
+    if (filters.favorites) {
+      params['favorites'] = true;
+    }
+
     return params;
   }
 }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -87,6 +87,8 @@ services:
       - JWT_REFRESH_SECRET=test-refresh-secret-key-min-32-chars!
       - PASSWORD_RESET_TOKEN_EXPIRY_HOURS=24
       - APP_BASE_URL=http://localhost:4200
+      - GMAIL_USER=test@example.com
+      - GMAIL_APP_PASSWORD=test-dummy-password
     depends_on:
       postgres-test:
         condition: service_healthy

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -27,6 +27,8 @@ tags:
     description: "Operaciones de consulta de niveles de dificultad de libros"
   - name: Categories
     description: "Operaciones de consulta de categorías (endpoint: /book-categories)"
+  - name: Favorites
+    description: "Operaciones de gestión de favoritos del usuario autenticado"
 
 paths:
   # ============================================
@@ -369,6 +371,7 @@ paths:
         - **categories**: Lista de categorías (OR entre valores, case-insensitive)
         - **levels**: Lista de niveles de dificultad (OR entre valores, case-insensitive)
         - **text**: Búsqueda semántica - genera un embedding y encuentra libros similares (≥55% similaridad, calibrado para nomic-embed-text)
+        - **favorites**: Cuando es `true` y el usuario tiene un JWT válido, devuelve únicamente los libros marcados como favoritos por el usuario. Si no hay JWT o el valor es `false`, el parámetro se ignora silenciosamente y el comportamiento es el estándar.
         
         ## Paginación
         
@@ -484,6 +487,19 @@ paths:
             type: string
             minLength: 1
             example: "eyJsYXN0SWQiOiI1NTBlODQwMC1lMjliLTQxZDQtYTcxNi00NDY2NTU0NDAwMDAiLCJsYXN0VmFsdWUiOiJDbGVhbiBDb2RlIn0="
+        - name: favorites
+          in: query
+          required: false
+          description: |
+            Cuando es `true` y el usuario está autenticado (JWT válido en cookie `access_token`),
+            devuelve únicamente los libros marcados como favoritos por el usuario.
+
+            Si el usuario no tiene JWT o el valor es `false`, el parámetro se ignora silenciosamente
+            y el comportamiento del endpoint es el estándar (sin filtro por favoritos).
+          schema:
+            type: boolean
+            default: false
+            example: true
       responses:
         '200':
           description: Búsqueda completada exitosamente
@@ -891,6 +907,8 @@ paths:
 
         - El correo se envía con el archivo adjunto (no como enlace)
         - No se requiere autenticación para este endpoint (según configuración del servidor)
+        - Si el usuario está autenticado (JWT válido en cookie `access_token`), se registra automáticamente
+          un registro de descarga asociado al usuario (operación fire-and-forget: no afecta la respuesta)
       operationId: sendBookByEmail
       parameters:
         - name: id
@@ -996,6 +1014,92 @@ paths:
                 data: null
                 error:
                   message: "Failed to send email"
+
+  # ============================================
+  # HU-039: Favorites and Access Control Endpoints
+  # ============================================
+
+  /books/{id}/favorite:
+    post:
+      tags:
+        - Favorites
+      summary: Alternar favorito de un libro
+      description: |
+        Alterna el estado de favorito del libro indicado para el usuario autenticado.
+
+        - Si el libro **no está** en favoritos del usuario, lo agrega y retorna `{ "favorite": true }`.
+        - Si el libro **ya está** en favoritos del usuario, lo elimina y retorna `{ "favorite": false }`.
+
+        ## Autenticación
+
+        Requiere un JWT válido en la cookie `access_token`. Si el token está ausente o es inválido,
+        se retorna `401 Unauthorized`.
+      operationId: toggleFavorite
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Identificador único del libro (UUID v4)
+          schema:
+            type: string
+            format: uuid
+            example: "550e8400-e29b-41d4-a716-446655440000"
+      responses:
+        '200':
+          description: Estado de favorito actualizado exitosamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FavoriteToggleResponse'
+              examples:
+                added_to_favorites:
+                  summary: Libro añadido a favoritos
+                  value:
+                    success: true
+                    data:
+                      favorite: true
+                    error: null
+                removed_from_favorites:
+                  summary: Libro eliminado de favoritos
+                  value:
+                    success: true
+                    data:
+                      favorite: false
+                    error: null
+        '401':
+          description: No autenticado. El token JWT está ausente o es inválido.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                missing_token:
+                  summary: Token ausente
+                  value:
+                    success: false
+                    data: null
+                    error:
+                      message: "Unauthorized"
+                invalid_token:
+                  summary: Token inválido o expirado
+                  value:
+                    success: false
+                    data: null
+                    error:
+                      message: "Unauthorized"
+        '404':
+          description: Libro no encontrado. No existe ningún libro con el `id` indicado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              example:
+                success: false
+                data: null
+                error:
+                  message: "Book with id \"550e8400-e29b-41d4-a716-446655440000\" not found"
 
   /book-types:
     get:
@@ -1771,8 +1875,38 @@ components:
               $ref: '#/components/schemas/BookSearchData'
 
     # ============================================
-    # HU-038: Authentication Schemas
+    # HU-039: Favorites and Access Control Schemas
     # ============================================
+
+    FavoriteToggleData:
+      type: object
+      required:
+        - favorite
+      properties:
+        favorite:
+          type: boolean
+          description: |
+            Estado del favorito tras la operación.
+            `true` si el libro fue añadido a favoritos, `false` si fue eliminado.
+          example: true
+
+    FavoriteToggleResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessResponse'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/FavoriteToggleData'
+
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: access_token
+      description: |
+        JWT de acceso almacenado en la cookie `access_token` (httpOnly).
+        Se establece automáticamente al hacer login con `POST /auth/login`.
+        Expira en 7 días. Puede renovarse con `POST /auth/refresh`.
 
     LoginRequest:
       type: object

--- a/docs/db/init-db.sql
+++ b/docs/db/init-db.sql
@@ -113,7 +113,7 @@ CREATE TABLE IF NOT EXISTS books (
     title VARCHAR(500) NOT NULL,
     type_id UUID NOT NULL REFERENCES types(id),
     format book_format NOT NULL,
-    available BOOLEAN NOT NULL DEFAULT FALSE,
+    available BOOLEAN NOT NULL DEFAULT TRUE,  -- default TRUE since migration 0001
     
     -- HU-013: Description fields
     -- original_description: stores the description in the original language
@@ -125,7 +125,7 @@ CREATE TABLE IF NOT EXISTS books (
     language VARCHAR(10) NOT NULL,
     
     -- Optional fields
-    isbn VARCHAR(32) UNIQUE,
+    isbn VARCHAR(32) UNIQUE,  -- varchar(32) since migration 0001
     path VARCHAR(1000),
     
     -- HU-008: Level is now a FK to levels table instead of enum
@@ -246,6 +246,72 @@ CREATE INDEX IF NOT EXISTS idx_book_categories_book_id
 -- Index for finding all books in a category
 CREATE INDEX IF NOT EXISTS idx_book_categories_category_id 
     ON book_categories (category_id);
+
+-- Users table (migration 0002 - authentication)
+CREATE TABLE IF NOT EXISTS users (
+    -- Primary key (UUID v4)
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Required fields
+    email TEXT NOT NULL,
+    password_hash TEXT NOT NULL,
+
+    -- Timestamps
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+
+    -- Constraints
+    CONSTRAINT users_email_unique UNIQUE (email)
+);
+
+-- Password reset tokens table (migration 0002)
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+    -- Primary key (UUID v4)
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Required fields
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+
+    -- Optional fields
+    used_at TIMESTAMPTZ
+);
+
+-- User book downloads table (migration 0003 - HU-039)
+CREATE TABLE IF NOT EXISTS user_book_downloads (
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    book_id UUID NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    downloaded_at TIMESTAMPTZ DEFAULT NOW(),
+
+    -- Composite primary key
+    CONSTRAINT user_book_downloads_user_id_book_id_pk PRIMARY KEY (user_id, book_id)
+);
+
+-- User book favorites table (migration 0003 - HU-039)
+CREATE TABLE IF NOT EXISTS user_book_favorites (
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    book_id UUID NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+
+    -- Composite primary key
+    CONSTRAINT user_book_favorites_user_id_book_id_pk PRIMARY KEY (user_id, book_id)
+);
+
+-- ================================
+-- Indexes (migration 0002–0003)
+-- ================================
+
+-- Users indexes
+CREATE INDEX IF NOT EXISTS users_email_idx
+    ON users USING btree (email);
+
+-- Password reset tokens indexes
+CREATE INDEX IF NOT EXISTS password_reset_tokens_user_idx
+    ON password_reset_tokens USING btree (user_id);
+
+-- User book favorites indexes (migration 0003)
+CREATE INDEX IF NOT EXISTS user_book_favorites_user_idx
+    ON user_book_favorites USING btree (user_id);
 
 -- ================================
 -- Triggers

--- a/docs/user_stories/36-hu-039-favorites-and-access-control.md
+++ b/docs/user_stories/36-hu-039-favorites-and-access-control.md
@@ -1,0 +1,277 @@
+# HU-039: Control de Acceso y Favoritos
+
+## Descripción
+
+**Como** usuario de la biblioteca digital,  
+**Quiero** que la interfaz se adapte según mi estado de autenticación y poder marcar libros como favoritos,  
+**Para** tener una experiencia personalizada y acceder rápidamente a los libros que más me interesan.
+
+---
+
+## Contexto y motivación
+
+En HU-038 se implementó el sistema de autenticación JWT. Sin embargo, la UI no aprovecha aún ese estado de sesión: la columna de acciones y el botón "Send to Kindle" son visibles para cualquier visitante aunque no pueda usarlos. Además, no existe ningún mecanismo de personalización por usuario.
+
+Esta historia completa la integración entre el sistema de identidad y la capa de presentación:
+
+- Los usuarios no autenticados ven el catálogo completo pero sin la columna de acciones.
+- Los usuarios autenticados ganan la capacidad de marcar favoritos y filtrar por ellos.
+- El flujo de "Send to Kindle" registra la descarga en base de datos, sentando las bases para estadísticas futuras.
+
+---
+
+## Criterios de Aceptación
+
+### CA-1: Columna de acciones — usuario no autenticado
+- La columna "Acciones" de `BookTableComponent` desaparece completamente para usuarios sin sesión: ni la cabecera ni las celdas son renderizadas.
+- El resto de la tabla (columnas, paginación, filtros por isbn, título, autor, tipo, categorías y nivel) funciona con normalidad.
+
+### CA-2: Columna de acciones — usuario autenticado
+- Los usuarios con sesión activa ven la columna "Acciones" con dos iconos:
+  - Icono existente `send_to_mobile` (material-symbols-outlined) — "Send to Kindle".
+  - Nuevo icono de favorito que refleja visualmente el estado actual del libro (favorito / no favorito).
+
+### CA-3: Toggle de favorito
+- Al pulsar el icono de favorito en un libro que **no** es favorito → el libro se añade a los favoritos del usuario y el icono cambia al estado activo.
+- Al pulsar el icono de favorito en un libro que **ya es** favorito → el libro se elimina de los favoritos y el icono vuelve al estado inactivo.
+- La operación es por usuario: los favoritos de un usuario no afectan a los de otro.
+
+### CA-4: Filtro "Mis favoritos"
+- El panel de filtros (`FilterPanelComponent`) muestra un checkbox "Mis favoritos" **solo** cuando hay sesión activa.
+- Con el checkbox marcado → la petición a `GET /api/books` incluye el parámetro `favorites: true` y la tabla muestra únicamente los libros marcados como favoritos por el usuario.
+- Con el checkbox desmarcado → el parámetro `favorites` no se envía y la tabla muestra el catálogo completo.
+
+### CA-5: Registro de descarga al enviar a Kindle
+- Al ejecutar "Send to Kindle" con éxito → además del envío por email, se registra en base de datos que ese usuario descargó ese libro (upsert: si ya existía la entrada se actualiza la fecha).
+- Solo se almacena la última fecha de descarga por par usuario+libro; no se acumulan registros.
+
+### CA-6: Endpoint `POST /api/books/:id/favorite`
+- Requiere JWT válido (leído desde la cookie `access_token`). Sin token válido → `401 Unauthorized`.
+- Comportamiento toggle: si el libro no estaba en favoritos lo añade (`201 Created`); si ya estaba lo elimina (`200 OK`).
+- El cuerpo de respuesta incluye el estado resultante: `{ favorite: boolean }`.
+- Si el libro no existe → `404 Not Found`.
+
+### CA-7: Parámetro `favorites` en `GET /api/books`
+- Acepta el nuevo parámetro de query opcional `favorites=true`.
+- Si hay JWT válido y `favorites=true` → devuelve solo los libros marcados como favoritos por ese usuario.
+- Si **no** hay JWT válido y se envía `favorites=true` → el parámetro se ignora silenciosamente (no lanza error) y se devuelve el catálogo completo.
+
+### CA-8: Registro de descarga en `POST /api/books/:id/send`
+- Además de enviar el email (comportamiento existente, sin cambios), registra la descarga en la tabla `user_book_downloads` (upsert por `userId + bookId`).
+- Requiere JWT válido; sin token → el email se envía igualmente pero no se registra la descarga (retrocompatibilidad).
+
+### CA-9: Tests
+- Tests unitarios para toda la lógica de dominio: entidades, Value Objects y casos de uso nuevos.
+- Tests de integración para los tres endpoints nuevos/modificados.
+- Tests E2E para los flujos de toggle de favorito y filtrado.
+- Cobertura mínima del 80% en el código nuevo.
+
+---
+
+## Diseño técnico de alto nivel
+
+### Entidades y Value Objects de dominio
+
+```typescript
+// src/domain/favorite/Favorite.ts
+Favorite {
+  userId: UserId    // Value Object (UUID) — reutilizado de HU-038
+  bookId: BookId    // Value Object (UUID)
+  createdAt: Date
+}
+
+// src/domain/download/Download.ts
+Download {
+  userId: UserId
+  bookId: BookId
+  downloadedAt: Date
+}
+```
+
+### Flujos (Hexagonal Architecture)
+
+```
+POST /api/books/:id/favorite
+  → [JWT middleware helper] verifyAccessToken(cookie)
+  → ToggleFavoriteUseCase
+      → FavoriteRepository.findByUserAndBook()   [Port]
+      → FavoriteRepository.add() | remove()      [Port]
+      → Response: { favorite: boolean }
+
+GET /api/books?favorites=true
+  → [JWT middleware helper] extractUserIfPresent(cookie)  // no lanza error si no hay token
+  → SearchBooksUseCase (modificado)
+      → BookRepository.findAll({ ..., favoritesOf: userId | undefined })  [Port]
+      → Response: Book[]
+
+POST /api/books/:id/send
+  → SendToKindleUseCase (modificado)
+      → EmailPort.send()                          [Port]  // sin cambios
+      → [si hay userId] DownloadRepository.upsert()      [Port]
+      → Response: { sent: boolean }
+```
+
+### Esquema de base de datos
+
+```sql
+-- Tabla user_book_favorites
+CREATE TABLE user_book_favorites (
+  user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  book_id     UUID NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+  created_at  TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  PRIMARY KEY (user_id, book_id)
+);
+
+-- Tabla user_book_downloads
+CREATE TABLE user_book_downloads (
+  user_id       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  book_id       UUID NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+  downloaded_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  PRIMARY KEY (user_id, book_id)
+);
+```
+
+### Cambios en la API
+
+| Método | Ruta | Cambio |
+|---|---|---|
+| `POST` | `/api/books/:id/favorite` | **NUEVO** — toggle favorito, requiere JWT |
+| `GET` | `/api/books` | **MODIFICADO** — acepta `favorites=true` opcional |
+| `POST` | `/api/books/:id/send` | **MODIFICADO** — registra descarga en DB (upsert) |
+
+### Helper JWT para rutas existentes
+
+Para no romper rutas que actualmente son públicas, se introduce un helper de extracción opcional de identidad:
+
+```typescript
+// src/infrastructure/http/middleware/extractUserIfPresent.ts
+// Lee la cookie access_token. Si es válida devuelve el userId; si no, devuelve undefined.
+// Nunca lanza error — permite que rutas públicas mantengan su comportamiento.
+async function extractUserIfPresent(request): Promise<UserId | undefined>
+```
+
+El endpoint `POST /api/books/:id/favorite` usa en cambio un helper estricto que sí lanza `401`:
+
+```typescript
+// src/infrastructure/http/middleware/requireAuth.ts
+async function requireAuth(request): Promise<UserId>  // lanza UnauthorizedError si no hay token válido
+```
+
+### Cambios en el cliente web
+
+| Componente | Cambio |
+|---|---|
+| `BookTableComponent` | Oculta columna "Acciones" (cabecera + celdas) si `!isAuthenticated` |
+| `BookTableComponent` | Añade icono de favorito con estado visual reactivo por fila |
+| `FilterPanelComponent` | Añade checkbox "Mis favoritos" visible solo si `isAuthenticated` |
+| `SearchFilters` (tipo) | Añade campo opcional `favorites?: boolean` |
+| `BookService` / `FavoriteService` | Nuevo `FavoriteService` con método `toggleFavorite(bookId)` |
+
+El estado de autenticación se consume desde el `AuthService` (HU-038) mediante Signal.
+
+---
+
+## Tareas técnicas
+
+### Tarea 1 — DB: nuevas tablas `user_book_favorites` y `user_book_downloads`
+**Branch**: `task/HU-039-01-db-schema`
+
+- [ ] Crear migración Drizzle con las tablas `user_book_favorites` y `user_book_downloads`.
+- [ ] Definir los schemas Drizzle correspondientes en `src/infrastructure/db/schema/`.
+- [ ] Ejecutar `npm run db:generate && npm run db:migrate` y verificar que aplica correctamente.
+
+### Tarea 2 — Dominio: entidades, puertos y errores
+**Branch**: `task/HU-039-02-domain`
+
+- [ ] Crear entidad `Favorite` en `src/domain/favorite/Favorite.ts` (constructor privado, `create()` / `fromPersistence()`).
+- [ ] Crear entidad `Download` en `src/domain/download/Download.ts`.
+- [ ] Reutilizar `BookId` y `UserId` existentes.
+- [ ] Definir interfaz `FavoriteRepository` en `src/domain/favorite/ports/FavoriteRepository.ts`:
+  - `findByUserAndBook(userId, bookId): Promise<Favorite | null>`
+  - `add(favorite: Favorite): Promise<void>`
+  - `remove(userId, bookId): Promise<void>`
+  - `findAllByUser(userId): Promise<BookId[]>`
+- [ ] Definir interfaz `DownloadRepository` en `src/domain/download/ports/DownloadRepository.ts`:
+  - `upsert(download: Download): Promise<void>`
+- [ ] Crear error de dominio `BookNotFoundError` si no existe aún.
+- [ ] Tests unitarios para entidades y Value Objects.
+
+### Tarea 3 — Casos de uso: favoritos y descarga
+**Branch**: `task/HU-039-03-use-cases`
+
+- [ ] Implementar `ToggleFavoriteUseCase` en `src/application/use-cases/favorite/ToggleFavoriteUseCase.ts`:
+  - Recibe `userId` y `bookId`.
+  - Si existe → elimina y devuelve `{ favorite: false }`.
+  - Si no existe → crea y devuelve `{ favorite: true }`.
+- [ ] Modificar `SearchBooksUseCase` para aceptar `favoritesOf?: UserId` y filtrar en consecuencia.
+- [ ] Implementar `RegisterDownloadUseCase` en `src/application/use-cases/download/RegisterDownloadUseCase.ts`:
+  - Recibe `userId` y `bookId`.
+  - Delega el upsert en `DownloadRepository`.
+- [ ] Tests unitarios para los tres casos de uso cubriendo casos feliz y de error.
+
+### Tarea 4 — Infraestructura: adaptadores Drizzle
+**Branch**: `task/HU-039-04-infra-adapters`
+
+- [ ] Implementar `DrizzleFavoriteRepository` en `src/infrastructure/db/repositories/DrizzleFavoriteRepository.ts`.
+- [ ] Implementar `DrizzleDownloadRepository` en `src/infrastructure/db/repositories/DrizzleDownloadRepository.ts`.
+- [ ] Modificar `DrizzleBookRepository` para soportar el filtro `favoritesOf` (JOIN con `user_book_favorites`).
+- [ ] Tests de integración de los tres repositorios.
+
+### Tarea 5 — HTTP: endpoints y middlewares
+**Branch**: `task/HU-039-05-http`
+
+- [ ] Crear helper `requireAuth` en `src/infrastructure/http/middleware/requireAuth.ts`.
+- [ ] Crear helper `extractUserIfPresent` en `src/infrastructure/http/middleware/extractUserIfPresent.ts`.
+- [ ] Registrar ruta `POST /api/books/:id/favorite` con `requireAuth` y schema Zod de respuesta.
+- [ ] Modificar handler de `GET /api/books` para extraer userId opcionalmente y pasar `favorites` al caso de uso.
+- [ ] Modificar handler de `POST /api/books/:id/send` para invocar `RegisterDownloadUseCase` si hay userId.
+- [ ] Mapear errores de dominio a códigos HTTP (`401`, `404`).
+- [ ] Tests E2E de los tres endpoints.
+
+### Tarea 6 — Web client: control de acceso y favoritos
+**Branch**: `task/HU-039-06-web`
+
+- [ ] Inyectar `AuthService` en `BookTableComponent`; ocultar columna "Acciones" con `@if (isAuthenticated())`.
+- [ ] Añadir icono de favorito (material-symbols-outlined) en la columna de acciones con binding de estado.
+- [ ] Crear `FavoriteService` en `apps/web-client/src/app/books/services/FavoriteService.ts` con método `toggleFavorite(bookId: string): Observable<{ favorite: boolean }>`.
+- [ ] Actualizar el tipo `SearchFilters` para incluir el campo `favorites?: boolean`.
+- [ ] Añadir checkbox "Mis favoritos" en `FilterPanelComponent` con `@if (isAuthenticated())`.
+- [ ] Emitir `favorites: true` en el evento de filtro cuando el checkbox está marcado; omitir el campo cuando no lo está.
+- [ ] Tests unitarios de `BookTableComponent`, `FilterPanelComponent` y `FavoriteService`.
+
+### Tarea 7 — Documentación OpenAPI
+**Branch**: `task/HU-039-07-openapi-docs`
+
+- [ ] Documentar el nuevo endpoint `POST /api/books/:id/favorite` en `docs/api/openapi.yaml`.
+- [ ] Actualizar la documentación de `GET /api/books` con el parámetro `favorites`.
+- [ ] Actualizar la documentación de `POST /api/books/:id/send` con el comportamiento de registro de descarga.
+- [ ] Incluir schemas de request, respuestas exitosas y errores (`401`, `404`).
+
+---
+
+## Dependencias externas
+
+| Dependencia | Motivo |
+|---|---|
+| HU-038 (JWT Auth) | `JwtService.verifyAccessToken()`, cookie `access_token`, `UserId` Value Object |
+| `jsonwebtoken` (ya instalado en HU-038) | Verificación del token en los nuevos middlewares |
+| Drizzle ORM (ya instalado) | Nuevos schemas y repositorios |
+| Angular Material Symbols (ya configurado) | Icono de favorito en la columna de acciones |
+
+---
+
+## Riesgos
+
+| Riesgo | Mitigación |
+|---|---|
+| El parámetro `favorites` ignorado silenciosamente puede generar confusión en el cliente | Documentar el comportamiento en OpenAPI con claridad; el cliente solo lo envía si hay sesión activa |
+| El JOIN de favoritos en `GET /api/books` puede impactar el rendimiento con grandes catálogos | Añadir índice en `user_book_favorites(user_id)` desde la migración inicial |
+| Modificar `SearchBooksUseCase` puede romper tests existentes de búsqueda | Parametrizar `favoritesOf` como opcional con valor por defecto `undefined`; ejecutar suite completa antes de merge |
+| El upsert de descarga falla silenciosamente si no hay userId | Comportamiento esperado (retrocompatibilidad); logear el intento en modo debug para facilitar diagnóstico |
+
+---
+
+**Historia creada**: Domingo, 10 de Mayo, 2026  
+**Estimación**: 8-10 horas  
+**Prioridad**: Media  
+**Complejidad**: Alta


### PR DESCRIPTION
## Resumen

Implementa la historia de usuario **HU-039: Control de Acceso y Favoritos**.

Closes #437

---

## Cambios principales

### 🗄️ Base de datos
- Nuevas tablas `user_book_favorites` y `user_book_downloads` con PK compuesta e índices en `userId`
- Migración Drizzle generada: `0003_organic_shiver_man.sql`

### 🧱 Dominio
- `BookId` value object
- Entidades `Favorite` y `Download` (inmutables, constructor privado + factory)
- Puertos `FavoriteRepository` y `DownloadRepository`

### ⚙️ Casos de uso
- `ToggleFavoriteUseCase` — toggle add/remove, valida existencia del libro (404 si no existe)
- `RegisterDownloadUseCase` — upsert fire-and-forget
- `SearchBooksUseCase` — extendido con `favoritesOf?: UserId`

### 🔌 Infraestructura
- `DrizzleFavoriteRepository` y `DrizzleDownloadRepository`
- `PostgresBookRepository` actualizado con filtro `favoritesOf` via `inArray`
- Helpers HTTP: `extractUserIfPresent` y `requireAuth`
- `FavoriteController` — `POST /api/books/:id/favorite` (201 add / 200 remove)
- `SearchBooksController` — enriquece resultados con `favorite: boolean` por usuario
- `SendBookByEmailController` — registra descarga fire-and-forget al enviar a Kindle

### 🌐 Web client
- Columna "Acciones" oculta para usuarios no autenticados (desktop)
- Tarjetas móviles (`book-card`) también ocultan acciones si no hay sesión
- Icono de favorito con estado optimista y protección contra clicks concurrentes (`pendingFavorites`)
- `FavoriteService` con `toggle(bookId)`
- Checkbox "Mis favoritos" en el panel de filtros (solo visible autenticado)
- Estado inicial del favorito cargado desde el servidor (`book.favorite`)

### 📄 OpenAPI
- Nuevo endpoint `POST /books/{id}/favorite` documentado con esquema, auth y respuestas
- `GET /books` — param `favorites` documentado
- `POST /books/{id}/send` — nota sobre registro de descarga

---

## Tests
- **Unit**: 27 tests de dominio + 10 tests `ToggleFavoriteUseCase` (incluye caso 404)
- **Integration**: adaptadores Drizzle cubiertos
- **E2E**: `favorites.e2e.test.ts` con flujo completo autenticado/no autenticado