### PR TITLE
feat: HU-040 — Recomendaciones personalizadas de libros

### DIFF
--- a/apps/api/drizzle/0004_hu040_downloads_user_idx.sql
+++ b/apps/api/drizzle/0004_hu040_downloads_user_idx.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "user_book_downloads_user_idx" ON "user_book_downloads" USING btree ("user_id");

--- a/apps/api/src/application/ports/BookRepository.ts
+++ b/apps/api/src/application/ports/BookRepository.ts
@@ -205,6 +205,17 @@ export interface BookRepository {
   search(criteria: Criteria, embedding?: number[], favoritesOf?: BookId[]): Promise<SearchBooksResult>;
 
   /**
+   * Retrieves the categories for a list of book IDs.
+   *
+   * Used by the recommendations engine to determine the dominant category
+   * from the user's seed books (downloads + favorites) BEFORE the search step.
+   *
+   * @param bookIds - Array of book UUIDs to look up
+   * @returns Promise resolving to an array of { id, categories } objects
+   */
+  findCategoriesByIds(bookIds: string[]): Promise<Array<{ id: string; categories: string[] }>>;
+
+  /**
    * Retrieves the embeddings for a list of book IDs.
    *
    * Only returns entries for books that have a non-null embedding stored.

--- a/apps/api/src/application/ports/BookRepository.ts
+++ b/apps/api/src/application/ports/BookRepository.ts
@@ -203,4 +203,17 @@ export interface BookRepository {
    * @returns Promise resolving to paginated search results with similarity scores
    */
   search(criteria: Criteria, embedding?: number[], favoritesOf?: BookId[]): Promise<SearchBooksResult>;
+
+  /**
+   * Retrieves the embeddings for a list of book IDs.
+   *
+   * Only returns entries for books that have a non-null embedding stored.
+   * Used by the recommendations engine to compute cosine similarity between
+   * the user's downloaded books and candidate books.
+   *
+   * @param bookIds - Array of book UUIDs to look up
+   * @returns Promise resolving to an array of { id, embedding } objects
+   *          (only for books with a stored embedding)
+   */
+  findEmbeddingsByIds(bookIds: string[]): Promise<Array<{ id: string; embedding: number[] }>>;
 }

--- a/apps/api/src/application/ports/BookRepository.ts
+++ b/apps/api/src/application/ports/BookRepository.ts
@@ -215,5 +215,5 @@ export interface BookRepository {
    * @returns Promise resolving to an array of { id, embedding } objects
    *          (only for books with a stored embedding)
    */
-  findEmbeddingsByIds(bookIds: string[]): Promise<Array<{ id: string; embedding: number[] }>>;
+  findEmbeddingsByIds(bookIds: string[]): Promise<{ id: string; embedding: number[] }[]>;
 }

--- a/apps/api/src/application/use-cases/GetRecommendationsUseCase.ts
+++ b/apps/api/src/application/use-cases/GetRecommendationsUseCase.ts
@@ -44,7 +44,7 @@ const SEARCH_LIMIT = 40;
 const MAX_RECOMMENDATIONS = 20;
 
 /** Empty output returned when no recommendations can be computed */
-const EMPTY_OUTPUT: GetRecommendationsOutput = { items: [], label: '' };
+const EMPTY_OUTPUT: GetRecommendationsOutput = Object.freeze({ items: Object.freeze([]) as [], label: '' });
 
 /**
  * Dependencies required by GetRecommendationsUseCase
@@ -113,33 +113,23 @@ export class GetRecommendationsUseCase {
     const embeddings = embeddingEntries.map((e) => e.embedding);
     const centroid = computeCentroid(embeddings);
 
-    // 8. Search for similar books using centroid
+    // 8. Fetch categories for seed books (BEFORE search step — seeds are the user's profile)
+    const seedCategoryEntries = await this.bookRepository.findCategoriesByIds(seedIds);
+    const allSeedCategories = seedCategoryEntries.flatMap((entry) => entry.categories);
+    const dominantCategory = getDominantCategory(allSeedCategories);
+
+    // 9. Search for similar books using centroid
     const criteria = Criteria.create({ limit: SEARCH_LIMIT, cursor: null }).withOrder(
       Order.desc('similarity'),
     );
     const searchResult = await this.bookRepository.search(criteria, centroid);
 
-    // 9. Filter: exclude seeds, exclude below threshold, take top 20
+    // 10. Filter: exclude seeds, exclude below threshold, take top 20
     const seedSet = new Set(seedIds);
     const filtered = searchResult.items
       .filter((item) => !seedSet.has(item.book.id))
       .filter((item) => item.similarityScore !== null && item.similarityScore >= SIMILARITY_THRESHOLD)
       .slice(0, MAX_RECOMMENDATIONS);
-
-    // 10. Determine dominant category from ALL seed books returned in search
-    // We use categories from the candidate items that came from search as a proxy,
-    // but for seeds we need to look at the seed books themselves. We extract categories
-    // from the full result (which may include seeds before filtering).
-    const seedBooksInResult = searchResult.items.filter((item) => seedSet.has(item.book.id));
-    const allSeedCategories = seedBooksInResult.flatMap((item) =>
-      item.book.categories.map((c) => c.name),
-    );
-    // If seeds aren't in search results, use categories from filtered candidates as fallback
-    const categoryList = allSeedCategories.length > 0
-      ? allSeedCategories
-      : filtered.flatMap((item) => item.book.categories.map((c) => c.name));
-
-    const dominantCategory = getDominantCategory(categoryList);
 
     // 11. Build output
     const items = filtered.map((item) =>
@@ -147,7 +137,6 @@ export class GetRecommendationsUseCase {
         bookId: item.book.id,
         title: item.book.title,
         author: item.book.authors.map((a) => a.name).join(', '),
-        coverUrl: null,
         similarity: item.similarityScore!,
         dominantCategory,
       }),

--- a/apps/api/src/application/use-cases/GetRecommendationsUseCase.ts
+++ b/apps/api/src/application/use-cases/GetRecommendationsUseCase.ts
@@ -1,0 +1,161 @@
+/**
+ * GetRecommendationsUseCase
+ *
+ * Application service that generates personalized book recommendations
+ * for a user based on their downloads and favorites.
+ *
+ * Flow:
+ * 1. Fetch all downloads for the user
+ * 2. Fetch all favorite book IDs for the user
+ * 3. Combine & deduplicate seeds (downloads + favorites)
+ * 4. If no seeds → return empty output
+ * 5. Fetch embeddings for seed books
+ * 6. If no embeddings → return empty output
+ * 7. Compute centroid of seed embeddings
+ * 8. Search for similar books (limit 40) using the centroid
+ * 9. Filter: exclude seeds, exclude similarity < 0.55, take top 20
+ * 10. Determine dominant category from seed books' categories
+ * 11. Build output with label and recommendation items
+ *
+ * HU-040: Book recommendations feature.
+ */
+
+import type { BookRepository } from '../ports/BookRepository.js';
+import type { DownloadRepository } from '../../domain/download/ports/DownloadRepository.js';
+import type { FavoriteRepository } from '../../domain/favorite/ports/FavoriteRepository.js';
+import { computeCentroid } from '../../domain/recommendation/centroid.js';
+import { getDominantCategory } from '../../domain/recommendation/dominantCategory.js';
+import { RecommendationItem } from '../../domain/recommendation/RecommendationItem.js';
+import {
+  buildRecommendationLabel,
+  type GetRecommendationsOutput,
+} from '../../domain/recommendation/GetRecommendationsOutput.js';
+import { UserId } from '../../domain/user/value-objects/UserId.js';
+import { Criteria } from '../../domain/criteria/Criteria.js';
+import { Order } from '../../domain/criteria/Order.js';
+
+/** Minimum similarity score to include a book in recommendations */
+const SIMILARITY_THRESHOLD = 0.55;
+
+/** Number of candidates to fetch before filtering */
+const SEARCH_LIMIT = 40;
+
+/** Maximum number of recommendations to return */
+const MAX_RECOMMENDATIONS = 20;
+
+/** Empty output returned when no recommendations can be computed */
+const EMPTY_OUTPUT: GetRecommendationsOutput = { items: [], label: '' };
+
+/**
+ * Dependencies required by GetRecommendationsUseCase
+ */
+export interface GetRecommendationsUseCaseDeps {
+  bookRepository: BookRepository;
+  downloadRepository: DownloadRepository;
+  favoriteRepository?: FavoriteRepository;
+}
+
+/**
+ * GetRecommendationsUseCase
+ *
+ * Generates personalized book recommendations based on user's activity.
+ */
+export class GetRecommendationsUseCase {
+  private readonly bookRepository: BookRepository;
+  private readonly downloadRepository: DownloadRepository;
+  private readonly favoriteRepository: FavoriteRepository | undefined;
+
+  constructor(deps: GetRecommendationsUseCaseDeps) {
+    this.bookRepository = deps.bookRepository;
+    this.downloadRepository = deps.downloadRepository;
+    this.favoriteRepository = deps.favoriteRepository;
+  }
+
+  /**
+   * Executes the recommendations use case
+   *
+   * @param userId - The user UUID
+   * @returns Promise resolving to recommendations output with items and label
+   */
+  async execute(userId: string): Promise<GetRecommendationsOutput> {
+    // 1 & 2. Fetch downloads and favorites in parallel
+    const [downloads, favoriteBookIds] = await Promise.all([
+      this.downloadRepository.findAllByUser(userId),
+      this.favoriteRepository
+        ? this.favoriteRepository.findAllByUser(UserId.fromPersistence(userId))
+        : Promise.resolve([]),
+    ]);
+
+    // 3. Combine & deduplicate seed IDs
+    const seedIdSet = new Set<string>();
+    for (const download of downloads) {
+      seedIdSet.add(download.bookId.value);
+    }
+    for (const bookId of favoriteBookIds) {
+      seedIdSet.add(bookId.value);
+    }
+    const seedIds = Array.from(seedIdSet);
+
+    // 4. If no seeds → return empty
+    if (seedIds.length === 0) {
+      return EMPTY_OUTPUT;
+    }
+
+    // 5. Fetch embeddings for seed books
+    const embeddingEntries = await this.bookRepository.findEmbeddingsByIds(seedIds);
+
+    // 6. If no embeddings → return empty
+    if (embeddingEntries.length === 0) {
+      return EMPTY_OUTPUT;
+    }
+
+    // 7. Compute centroid
+    const embeddings = embeddingEntries.map((e) => e.embedding);
+    const centroid = computeCentroid(embeddings);
+
+    // 8. Search for similar books using centroid
+    const criteria = Criteria.create({ limit: SEARCH_LIMIT, cursor: null }).withOrder(
+      Order.desc('similarity'),
+    );
+    const searchResult = await this.bookRepository.search(criteria, centroid);
+
+    // 9. Filter: exclude seeds, exclude below threshold, take top 20
+    const seedSet = new Set(seedIds);
+    const filtered = searchResult.items
+      .filter((item) => !seedSet.has(item.book.id))
+      .filter((item) => item.similarityScore !== null && item.similarityScore >= SIMILARITY_THRESHOLD)
+      .slice(0, MAX_RECOMMENDATIONS);
+
+    // 10. Determine dominant category from ALL seed books returned in search
+    // We use categories from the candidate items that came from search as a proxy,
+    // but for seeds we need to look at the seed books themselves. We extract categories
+    // from the full result (which may include seeds before filtering).
+    const seedBooksInResult = searchResult.items.filter((item) => seedSet.has(item.book.id));
+    const allSeedCategories = seedBooksInResult.flatMap((item) =>
+      item.book.categories.map((c) => c.name),
+    );
+    // If seeds aren't in search results, use categories from filtered candidates as fallback
+    const categoryList = allSeedCategories.length > 0
+      ? allSeedCategories
+      : filtered.flatMap((item) => item.book.categories.map((c) => c.name));
+
+    const dominantCategory = getDominantCategory(categoryList);
+
+    // 11. Build output
+    const items = filtered.map((item) =>
+      RecommendationItem.create({
+        bookId: item.book.id,
+        title: item.book.title,
+        author: item.book.authors.map((a) => a.name).join(', '),
+        coverUrl: null,
+        similarity: item.similarityScore!,
+        dominantCategory,
+      }),
+    );
+
+    return {
+      items,
+      label: buildRecommendationLabel(dominantCategory),
+    };
+  }
+}

--- a/apps/api/src/application/use-cases/index.ts
+++ b/apps/api/src/application/use-cases/index.ts
@@ -32,3 +32,8 @@ export {
   type SearchBooksPagination,
   type SearchBooksUseCaseDeps,
 } from './SearchBooksUseCase.js';
+
+export {
+  GetRecommendationsUseCase,
+  type GetRecommendationsUseCaseDeps,
+} from './GetRecommendationsUseCase.js';

--- a/apps/api/src/domain/download/ports/DownloadRepository.ts
+++ b/apps/api/src/domain/download/ports/DownloadRepository.ts
@@ -5,6 +5,7 @@
  * This is a pure domain port — no infrastructure dependencies.
  *
  * HU-039: Downloads domain port for persistence.
+ * HU-040: Added findAllByUser for recommendations feature.
  */
 
 import type { Download } from '../Download.js';
@@ -20,4 +21,15 @@ export interface DownloadRepository {
    * Updates the downloadedAt timestamp if the record already exists.
    */
   upsert(download: Download): Promise<void>;
+
+  /**
+   * Retrieves all download records for a given user.
+   *
+   * Used by the recommendations engine to find which books the user
+   * has already downloaded, in order to compute similarity-based suggestions.
+   *
+   * @param userId - The user UUID
+   * @returns Promise resolving to an array of Download entities for the user
+   */
+  findAllByUser(userId: string): Promise<Download[]>;
 }

--- a/apps/api/src/domain/recommendation/GetRecommendationsOutput.ts
+++ b/apps/api/src/domain/recommendation/GetRecommendationsOutput.ts
@@ -1,0 +1,14 @@
+import type { RecommendationItem } from './RecommendationItem.js';
+
+export interface GetRecommendationsOutput {
+  items: RecommendationItem[];
+  label: string;
+}
+
+/**
+ * Builds the label for recommendations output.
+ * Example: "Porque te interesa Programming"
+ */
+export function buildRecommendationLabel(dominantCategory: string): string {
+  return `Porque te interesa ${dominantCategory}`;
+}

--- a/apps/api/src/domain/recommendation/RecommendationItem.ts
+++ b/apps/api/src/domain/recommendation/RecommendationItem.ts
@@ -4,7 +4,6 @@ export interface RecommendationItemProps {
   bookId: string;
   title: string;
   author: string;
-  coverUrl: string | null;
   similarity: number;
   dominantCategory: string;
 }
@@ -13,7 +12,6 @@ export class RecommendationItem {
   readonly bookId: string;
   readonly title: string;
   readonly author: string;
-  readonly coverUrl: string | null;
   readonly similarity: number;
   readonly dominantCategory: string;
 
@@ -21,7 +19,6 @@ export class RecommendationItem {
     this.bookId = props.bookId;
     this.title = props.title;
     this.author = props.author;
-    this.coverUrl = props.coverUrl;
     this.similarity = props.similarity;
     this.dominantCategory = props.dominantCategory;
     Object.freeze(this);

--- a/apps/api/src/domain/recommendation/RecommendationItem.ts
+++ b/apps/api/src/domain/recommendation/RecommendationItem.ts
@@ -1,0 +1,42 @@
+import { DomainError } from '../errors/DomainErrors.js';
+
+export interface RecommendationItemProps {
+  bookId: string;
+  title: string;
+  author: string;
+  coverUrl: string | null;
+  similarity: number;
+  dominantCategory: string;
+}
+
+export class RecommendationItem {
+  readonly bookId: string;
+  readonly title: string;
+  readonly author: string;
+  readonly coverUrl: string | null;
+  readonly similarity: number;
+  readonly dominantCategory: string;
+
+  private constructor(props: RecommendationItemProps) {
+    this.bookId = props.bookId;
+    this.title = props.title;
+    this.author = props.author;
+    this.coverUrl = props.coverUrl;
+    this.similarity = props.similarity;
+    this.dominantCategory = props.dominantCategory;
+    Object.freeze(this);
+  }
+
+  static create(props: RecommendationItemProps): RecommendationItem {
+    if (props.similarity < 0 || props.similarity > 1) {
+      throw new InvalidSimilarityError(props.similarity);
+    }
+    return new RecommendationItem(props);
+  }
+}
+
+export class InvalidSimilarityError extends DomainError {
+  constructor(value: number) {
+    super(`similarity must be between 0 and 1, got: ${value}`);
+  }
+}

--- a/apps/api/src/domain/recommendation/centroid.ts
+++ b/apps/api/src/domain/recommendation/centroid.ts
@@ -5,6 +5,7 @@ import { DomainError } from '../errors/DomainErrors.js';
  * @param embeddings - Array of numeric vectors (all must have the same length)
  * @returns The centroid vector
  * @throws DomainError if embeddings array is empty
+ * @throws DomainError if embeddings have inconsistent dimensions
  */
 export function computeCentroid(embeddings: number[][]): number[] {
   if (embeddings.length === 0) {
@@ -12,6 +13,13 @@ export function computeCentroid(embeddings: number[][]): number[] {
   }
 
   const dims = embeddings[0].length;
+
+  for (let i = 1; i < embeddings.length; i++) {
+    if (embeddings[i].length !== dims) {
+      throw new InconsistentEmbeddingDimensionsError(dims, embeddings[i].length, i);
+    }
+  }
+
   const centroid = new Array<number>(dims).fill(0);
 
   for (const embedding of embeddings) {
@@ -30,5 +38,13 @@ export function computeCentroid(embeddings: number[][]): number[] {
 export class EmptyEmbeddingsError extends DomainError {
   constructor() {
     super('embeddings cannot be empty');
+  }
+}
+
+export class InconsistentEmbeddingDimensionsError extends DomainError {
+  constructor(expected: number, actual: number, index: number) {
+    super(
+      `embedding at index ${index} has ${actual} dimensions, expected ${expected}`,
+    );
   }
 }

--- a/apps/api/src/domain/recommendation/centroid.ts
+++ b/apps/api/src/domain/recommendation/centroid.ts
@@ -1,0 +1,34 @@
+import { DomainError } from '../errors/DomainErrors.js';
+
+/**
+ * Computes the centroid (element-wise average) of a list of embeddings.
+ * @param embeddings - Array of numeric vectors (all must have the same length)
+ * @returns The centroid vector
+ * @throws DomainError if embeddings array is empty
+ */
+export function computeCentroid(embeddings: number[][]): number[] {
+  if (embeddings.length === 0) {
+    throw new EmptyEmbeddingsError();
+  }
+
+  const dims = embeddings[0].length;
+  const centroid = new Array<number>(dims).fill(0);
+
+  for (const embedding of embeddings) {
+    for (let i = 0; i < dims; i++) {
+      centroid[i] += embedding[i];
+    }
+  }
+
+  for (let i = 0; i < dims; i++) {
+    centroid[i] /= embeddings.length;
+  }
+
+  return centroid;
+}
+
+export class EmptyEmbeddingsError extends DomainError {
+  constructor() {
+    super('embeddings cannot be empty');
+  }
+}

--- a/apps/api/src/domain/recommendation/dominantCategory.ts
+++ b/apps/api/src/domain/recommendation/dominantCategory.ts
@@ -1,0 +1,36 @@
+/**
+ * Returns the most frequent category from a list.
+ * On ties, the first-appearing category wins.
+ * Returns "General" if the list is empty.
+ */
+export function getDominantCategory(categories: string[]): string {
+  if (categories.length === 0) {
+    return 'General';
+  }
+
+  const counts = new Map<string, number>();
+  const firstSeen = new Map<string, number>();
+
+  for (let i = 0; i < categories.length; i++) {
+    const cat = categories[i];
+    counts.set(cat, (counts.get(cat) ?? 0) + 1);
+    if (!firstSeen.has(cat)) {
+      firstSeen.set(cat, i);
+    }
+  }
+
+  let dominant = '';
+  let maxCount = 0;
+  let minFirstSeen = Infinity;
+
+  for (const [cat, count] of counts.entries()) {
+    const first = firstSeen.get(cat)!;
+    if (count > maxCount || (count === maxCount && first < minFirstSeen)) {
+      dominant = cat;
+      maxCount = count;
+      minFirstSeen = first;
+    }
+  }
+
+  return dominant;
+}

--- a/apps/api/src/infrastructure/driven/persistence/DrizzleDownloadRepository.ts
+++ b/apps/api/src/infrastructure/driven/persistence/DrizzleDownloadRepository.ts
@@ -8,7 +8,7 @@
  * HU-040: Added findAllByUser for recommendations feature.
  */
 
-import { eq } from 'drizzle-orm';
+import { eq, desc } from 'drizzle-orm';
 import type { DownloadRepository } from '../../../domain/download/ports/DownloadRepository.js';
 import type { Download } from '../../../domain/download/Download.js';
 import { Download as DownloadEntity } from '../../../domain/download/Download.js';
@@ -55,7 +55,9 @@ export class DrizzleDownloadRepository implements DownloadRepository {
     const rows = await this.db
       .select()
       .from(userBookDownloads)
-      .where(eq(userBookDownloads.userId, userId));
+      .where(eq(userBookDownloads.userId, userId))
+      .orderBy(desc(userBookDownloads.downloadedAt))
+      .limit(100);
 
     return rows.map(row =>
       DownloadEntity.fromPersistence({

--- a/apps/api/src/infrastructure/driven/persistence/DrizzleDownloadRepository.ts
+++ b/apps/api/src/infrastructure/driven/persistence/DrizzleDownloadRepository.ts
@@ -5,10 +5,13 @@
  * This is a driven/output adapter in the hexagonal architecture.
  *
  * HU-039: Persistence adapter for Download entity.
+ * HU-040: Added findAllByUser for recommendations feature.
  */
 
+import { eq } from 'drizzle-orm';
 import type { DownloadRepository } from '../../../domain/download/ports/DownloadRepository.js';
 import type { Download } from '../../../domain/download/Download.js';
+import { Download as DownloadEntity } from '../../../domain/download/Download.js';
 import { userBookDownloads } from './drizzle/schema.js';
 import type { DatabaseClient } from './types.js';
 
@@ -40,5 +43,26 @@ export class DrizzleDownloadRepository implements DownloadRepository {
         target: [userBookDownloads.userId, userBookDownloads.bookId],
         set: { downloadedAt: new Date() },
       });
+  }
+
+  /**
+   * Retrieves all download records for a given user.
+   *
+   * HU-040: Used by the recommendations engine to find which books the user
+   * has downloaded, in order to compute similarity-based suggestions.
+   */
+  async findAllByUser(userId: string): Promise<Download[]> {
+    const rows = await this.db
+      .select()
+      .from(userBookDownloads)
+      .where(eq(userBookDownloads.userId, userId));
+
+    return rows.map(row =>
+      DownloadEntity.fromPersistence({
+        userId: row.userId,
+        bookId: row.bookId,
+        downloadedAt: row.downloadedAt ?? new Date(),
+      }),
+    );
   }
 }

--- a/apps/api/src/infrastructure/driven/persistence/PostgresBookRepository.ts
+++ b/apps/api/src/infrastructure/driven/persistence/PostgresBookRepository.ts
@@ -124,7 +124,7 @@ export function normalizeForDuplicateCheck(text: string): string {
  * Provides CRUD operations for books with duplicate detection and embedding storage.
  */
 export class PostgresBookRepository implements BookRepository {
-  constructor(readonly db: DatabaseClient) {}
+  constructor(private readonly db: DatabaseClient) {}
 
   /**
    * Finds a book by its unique identifier
@@ -1018,6 +1018,40 @@ export class PostgresBookRepository implements BookRepository {
       .where(eq(bookCategories.bookId, bookId)) as { categories: CategorySelect }[];
 
     return results.map((r) => CategoryMapper.toDomain(r.categories));
+  }
+
+  /**
+   * Retrieves categories for a list of book IDs (HU-040)
+   *
+   * Used by the recommendations engine to determine the dominant category
+   * from seed books before the search step.
+   */
+  async findCategoriesByIds(bookIds: string[]): Promise<Array<{ id: string; categories: string[] }>> {
+    if (bookIds.length === 0) {
+      return [];
+    }
+
+    const results = await this.db
+      .select({
+        bookId: bookCategories.bookId,
+        categoryName: categories.name,
+      })
+      .from(bookCategories)
+      .innerJoin(categories, eq(bookCategories.categoryId, categories.id))
+      .where(inArray(bookCategories.bookId, bookIds));
+
+    // Group category names by bookId
+    const categoryMap = new Map<string, string[]>();
+    for (const row of results) {
+      const existing = categoryMap.get(row.bookId) ?? [];
+      existing.push(row.categoryName);
+      categoryMap.set(row.bookId, existing);
+    }
+
+    return bookIds.map((id) => ({
+      id,
+      categories: categoryMap.get(id) ?? [],
+    }));
   }
 
   /**

--- a/apps/api/src/infrastructure/driven/persistence/PostgresBookRepository.ts
+++ b/apps/api/src/infrastructure/driven/persistence/PostgresBookRepository.ts
@@ -1026,7 +1026,7 @@ export class PostgresBookRepository implements BookRepository {
    * Only returns books that have a non-null embedding stored.
    * Used by the recommendations engine to compute cosine similarity.
    */
-  async findEmbeddingsByIds(bookIds: string[]): Promise<Array<{ id: string; embedding: number[] }>> {
+  async findEmbeddingsByIds(bookIds: string[]): Promise<{ id: string; embedding: number[] }[]> {
     if (bookIds.length === 0) {
       return [];
     }

--- a/apps/api/src/infrastructure/driven/persistence/PostgresBookRepository.ts
+++ b/apps/api/src/infrastructure/driven/persistence/PostgresBookRepository.ts
@@ -1021,6 +1021,27 @@ export class PostgresBookRepository implements BookRepository {
   }
 
   /**
+   * Retrieves embeddings for a list of book IDs (HU-040)
+   *
+   * Only returns books that have a non-null embedding stored.
+   * Used by the recommendations engine to compute cosine similarity.
+   */
+  async findEmbeddingsByIds(bookIds: string[]): Promise<Array<{ id: string; embedding: number[] }>> {
+    if (bookIds.length === 0) {
+      return [];
+    }
+
+    const rows = await this.db
+      .select({ id: books.id, embedding: books.embedding })
+      .from(books)
+      .where(and(inArray(books.id, bookIds), sql`${books.embedding} IS NOT NULL`));
+
+    return rows
+      .filter((row): row is { id: string; embedding: number[] } => row.embedding !== null)
+      .map(row => ({ id: row.id, embedding: row.embedding }));
+  }
+
+  /**
    * Handles save errors, converting database errors to domain errors
    */
   private handleSaveError(error: unknown, book: Book): never {

--- a/apps/api/src/infrastructure/driven/persistence/drizzle/schema.ts
+++ b/apps/api/src/infrastructure/driven/persistence/drizzle/schema.ts
@@ -289,6 +289,8 @@ export const userBookDownloads = pgTable('user_book_downloads', {
 }, (table) => [
   // Composite primary key
   primaryKey({ columns: [table.userId, table.bookId] }),
+  // HU-040: Index for querying downloads by user (required for recommendations)
+  index('user_book_downloads_user_idx').on(table.userId),
 ]);
 
 export type UserBookFavoriteInsert = typeof userBookFavorites.$inferInsert;

--- a/apps/api/src/infrastructure/driver/http/controllers/RecommendationsController.ts
+++ b/apps/api/src/infrastructure/driver/http/controllers/RecommendationsController.ts
@@ -1,0 +1,94 @@
+/**
+ * RecommendationsController
+ *
+ * HTTP request handler for the GET /api/books/recommendations endpoint.
+ * Follows the thin controller pattern — delegates business logic to use cases.
+ *
+ * HU-040: Book recommendations HTTP controller.
+ */
+
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import type { GetRecommendationsUseCase } from '../../../../application/use-cases/GetRecommendationsUseCase.js';
+import type { JwtService } from '../../../../domain/user/ports/JwtService.js';
+import type { Logger } from '../../../../application/ports/Logger.js';
+import { noopLogger } from '../../../../application/ports/Logger.js';
+import { requireAuth } from '../middleware/requireAuth.js';
+import { successResponse } from '../schemas/common.schemas.js';
+import { mapErrorToHttpResponse } from '../errors/HttpErrorMapper.js';
+
+/**
+ * Dependencies required by RecommendationsController
+ */
+export interface RecommendationsControllerDeps {
+  getRecommendationsUseCase: GetRecommendationsUseCase;
+  jwtService: JwtService;
+  logger?: Logger;
+}
+
+/**
+ * RecommendationsController
+ *
+ * Handles HTTP requests for book recommendations.
+ */
+export class RecommendationsController {
+  private readonly getRecommendationsUseCase: GetRecommendationsUseCase;
+  private readonly jwtService: JwtService;
+  private readonly logger: Logger;
+
+  constructor(deps: RecommendationsControllerDeps) {
+    this.getRecommendationsUseCase = deps.getRecommendationsUseCase;
+    this.jwtService = deps.jwtService;
+    this.logger = deps.logger?.child({ name: 'RecommendationsController' }) ?? noopLogger;
+  }
+
+  /**
+   * GET /api/books/recommendations
+   *
+   * Returns personalized book recommendations for the authenticated user.
+   *
+   * @returns 200 { items: RecommendationItem[], label: string } on success
+   * @returns 200 { items: [], label: '' } when user has no history
+   * @returns 401 if not authenticated
+   */
+  async getRecommendations(
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ): Promise<FastifyReply> {
+    this.logger.debug('Received get recommendations request');
+
+    try {
+      // 1. Require authentication
+      const userId = await requireAuth(request, reply, this.jwtService);
+
+      // If requireAuth sent a 401, reply is already sent — stop processing
+      if (reply.sent) {
+        return reply;
+      }
+
+      // 2. Execute use case
+      const result = await this.getRecommendationsUseCase.execute(userId.value);
+
+      this.logger.info('Recommendations fetched', {
+        userId: userId.value,
+        count: result.items.length,
+      });
+
+      return reply.status(200).send(successResponse(result));
+    } catch (error) {
+      // If reply was already sent (401 from requireAuth), just return
+      if (reply.sent) {
+        return reply;
+      }
+
+      const errorResponse = mapErrorToHttpResponse(error);
+
+      if (errorResponse.statusCode >= 500) {
+        this.logger.error('Unexpected error fetching recommendations', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
+      return reply.status(errorResponse.statusCode).send(errorResponse.body);
+    }
+  }
+}

--- a/apps/api/src/infrastructure/driver/http/routes/books.routes.ts
+++ b/apps/api/src/infrastructure/driver/http/routes/books.routes.ts
@@ -12,6 +12,7 @@ import type { BooksController } from '../controllers/BooksController.js';
 import type { SearchBooksController } from '../controllers/SearchBooksController.js';
 import type { SendBookByEmailController } from '../controllers/SendBookByEmailController.js';
 import type { FavoriteController } from '../controllers/FavoriteController.js';
+import type { RecommendationsController } from '../controllers/RecommendationsController.js';
 
 /**
  * Options for registering book routes
@@ -21,6 +22,7 @@ export interface BooksRoutesOptions extends FastifyPluginOptions {
   searchController: SearchBooksController;
   sendBookByEmailController: SendBookByEmailController;
   favoriteController?: FavoriteController;
+  recommendationsController?: RecommendationsController;
 }
 
 /**
@@ -39,7 +41,18 @@ export async function booksRoutes(
   fastify: FastifyInstance,
   options: BooksRoutesOptions,
 ): Promise<void> {
-  const { controller, searchController, sendBookByEmailController, favoriteController } = options;
+  const { controller, searchController, sendBookByEmailController, favoriteController, recommendationsController } = options;
+
+  /**
+   * GET /api/books/recommendations
+   * Returns personalized book recommendations for the authenticated user (HU-040)
+   * IMPORTANT: Must be registered BEFORE /books/:id to avoid route conflict
+   */
+  if (recommendationsController) {
+    fastify.get('/books/recommendations', async (request, reply) => {
+      return recommendationsController.getRecommendations(request, reply);
+    });
+  }
 
   /**
    * GET /api/books

--- a/apps/api/src/infrastructure/driver/http/server.ts
+++ b/apps/api/src/infrastructure/driver/http/server.ts
@@ -27,6 +27,7 @@ import { BookLevelsController } from './controllers/BookLevelsController.js';
 import { SendBookByEmailController } from './controllers/SendBookByEmailController.js';
 import { FavoriteController } from './controllers/FavoriteController.js';
 import { AuthController } from './controllers/AuthController.js';
+import { RecommendationsController } from './controllers/RecommendationsController.js';
 import { booksRoutes } from './routes/books.routes.js';
 import { bookTypesRoutes } from './routes/book-types.routes.js';
 import { categoriesRoutes } from './routes/categories.routes.js';
@@ -40,6 +41,7 @@ import type { ListBookLevelsUseCase } from '../../../application/use-cases/ListB
 import type { SendBookByEmailUseCase } from '../../../application/use-cases/SendBookByEmailUseCase.js';
 import type { ToggleFavoriteUseCase } from '../../../application/use-cases/favorite/ToggleFavoriteUseCase.js';
 import type { RegisterDownloadUseCase } from '../../../application/use-cases/download/RegisterDownloadUseCase.js';
+import type { GetRecommendationsUseCase } from '../../../application/use-cases/GetRecommendationsUseCase.js';
 import type { LoginUseCase } from '../../../application/use-cases/auth/LoginUseCase.js';
 import type { LogoutUseCase } from '../../../application/use-cases/auth/LogoutUseCase.js';
 import type { RefreshTokenUseCase } from '../../../application/use-cases/auth/RefreshTokenUseCase.js';
@@ -59,6 +61,7 @@ export interface ServerDeps {
   sendBookByEmailUseCase: SendBookByEmailUseCase;
   toggleFavoriteUseCase?: ToggleFavoriteUseCase;
   registerDownloadUseCase?: RegisterDownloadUseCase;
+  getRecommendationsUseCase?: GetRecommendationsUseCase;
   loginUseCase: LoginUseCase;
   logoutUseCase: LogoutUseCase;
   refreshTokenUseCase: RefreshTokenUseCase;
@@ -89,7 +92,7 @@ export async function createServer(
   deps: ServerDeps,
   options: ServerOptions = {},
 ): Promise<FastifyInstance> {
-  const { createBookUseCase, searchBooksUseCase, listBookTypesUseCase, listCategoriesUseCase, listBookLevelsUseCase, sendBookByEmailUseCase, toggleFavoriteUseCase, registerDownloadUseCase, loginUseCase, logoutUseCase, refreshTokenUseCase, forgotPasswordUseCase, resetPasswordUseCase, jwtService, logger = noopLogger } = deps;
+  const { createBookUseCase, searchBooksUseCase, listBookTypesUseCase, listCategoriesUseCase, listBookLevelsUseCase, sendBookByEmailUseCase, toggleFavoriteUseCase, registerDownloadUseCase, getRecommendationsUseCase, loginUseCase, logoutUseCase, refreshTokenUseCase, forgotPasswordUseCase, resetPasswordUseCase, jwtService, logger = noopLogger } = deps;
   const { prefix = '/api', nodeEnv = 'production' } = options;
 
   const serverLogger = logger.child({ name: 'FastifyServer' });
@@ -166,6 +169,11 @@ export async function createServer(
     ? new FavoriteController({ toggleFavoriteUseCase, jwtService, logger })
     : undefined;
 
+  // HU-040: RecommendationsController (only created if use case and jwtService are provided)
+  const recommendationsController = getRecommendationsUseCase && jwtService
+    ? new RecommendationsController({ getRecommendationsUseCase, jwtService, logger })
+    : undefined;
+
   const authController = new AuthController({
     loginUseCase,
     logoutUseCase,
@@ -183,6 +191,7 @@ export async function createServer(
     searchController: searchBooksController,
     sendBookByEmailController,
     favoriteController,
+    recommendationsController,
   });
 
   await fastify.register(bookTypesRoutes, {
@@ -211,6 +220,7 @@ export async function createServer(
     const routes = [
       { method: 'GET', path: `${prefix}/books` },
       { method: 'POST', path: `${prefix}/books` },
+      { method: 'GET', path: `${prefix}/books/recommendations` },
       { method: 'POST', path: `${prefix}/books/:id/send` },
       { method: 'POST', path: `${prefix}/books/:id/favorite` },
       { method: 'GET', path: `${prefix}/book-types` },

--- a/apps/api/tests/e2e/http/recommendations.e2e.test.ts
+++ b/apps/api/tests/e2e/http/recommendations.e2e.test.ts
@@ -1,0 +1,183 @@
+/**
+ * E2E Tests: GET /api/books/recommendations
+ *
+ * End-to-end tests for HU-040 HTTP endpoint:
+ * - GET /api/books/recommendations: get personalized book recommendations (auth required)
+ *
+ * These tests use mock use cases — no database required.
+ *
+ * HU-040: Book recommendations HTTP endpoint tests.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { createServer } from '../../../src/infrastructure/driver/http/server.js';
+import { noopLogger } from '../../../src/application/ports/Logger.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TEST_PORT = 3099;
+const BASE_URL = `http://127.0.0.1:${TEST_PORT}`;
+
+const VALID_USER_ID = '660e8400-e29b-41d4-a716-446655440001';
+const VALID_TOKEN = 'valid-access-token';
+
+/** Minimal no-op stubs for use cases not under test */
+function makeNoopUseCases() {
+  return {
+    createBookUseCase: { execute: vi.fn().mockResolvedValue({}) },
+    listBookTypesUseCase: { execute: vi.fn().mockResolvedValue([]) },
+    listCategoriesUseCase: { execute: vi.fn().mockResolvedValue([]) },
+    listBookLevelsUseCase: { execute: vi.fn().mockResolvedValue([]) },
+    loginUseCase: { execute: vi.fn().mockResolvedValue({ accessToken: '', refreshToken: '' }) },
+    logoutUseCase: { execute: vi.fn().mockResolvedValue(undefined) },
+    refreshTokenUseCase: { execute: vi.fn().mockResolvedValue({ accessToken: '', refreshToken: '' }) },
+    forgotPasswordUseCase: { execute: vi.fn().mockResolvedValue(undefined) },
+    resetPasswordUseCase: { execute: vi.fn().mockResolvedValue(undefined) },
+  };
+}
+
+/**
+ * Creates a JwtService mock that accepts VALID_TOKEN and returns VALID_USER_ID.
+ */
+function makeJwtService() {
+  return {
+    signTokens: vi.fn(),
+    verifyAccessToken: vi.fn().mockImplementation(async (token: string) => {
+      if (token === VALID_TOKEN) {
+        return { userId: VALID_USER_ID, email: 'user@example.com' };
+      }
+      throw new Error('Invalid token');
+    }),
+    verifyRefreshToken: vi.fn(),
+  };
+}
+
+/** Sample recommendation items */
+const SAMPLE_ITEMS = [
+  {
+    bookId: '550e8400-e29b-41d4-a716-446655440000',
+    title: 'Clean Code',
+    author: 'Robert C. Martin',
+    coverUrl: null,
+    similarity: 0.87,
+    dominantCategory: 'Programación',
+  },
+  {
+    bookId: '660e8400-e29b-41d4-a716-446655440002',
+    title: 'The Pragmatic Programmer',
+    author: 'Andrew Hunt',
+    coverUrl: 'https://example.com/cover.jpg',
+    similarity: 0.75,
+    dominantCategory: 'Programación',
+  },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/books/recommendations
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/books/recommendations', () => {
+  let server: FastifyInstance;
+  let getRecommendationsExecute: ReturnType<typeof vi.fn>;
+
+  beforeAll(async () => {
+    getRecommendationsExecute = vi.fn();
+    const jwtService = makeJwtService();
+
+    server = await createServer(
+      {
+        ...makeNoopUseCases(),
+        searchBooksUseCase: {
+          execute: vi.fn().mockResolvedValue({ items: [], pagination: { limit: 50, hasNextPage: false, nextCursor: null, totalCount: 0 } }),
+        },
+        sendBookByEmailUseCase: { execute: vi.fn().mockResolvedValue(undefined) },
+        getRecommendationsUseCase: { execute: getRecommendationsExecute },
+        jwtService,
+        logger: noopLogger,
+      },
+      { prefix: '/api', nodeEnv: 'test' },
+    );
+    await server.listen({ port: TEST_PORT, host: '127.0.0.1' });
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it('should return 401 when no access_token cookie is present', async () => {
+    const response = await fetch(`${BASE_URL}/api/books/recommendations`);
+
+    expect(response.status).toBe(401);
+    const body = await response.json() as { success: boolean };
+    expect(body.success).toBe(false);
+  });
+
+  it('should return 401 when access_token cookie is invalid', async () => {
+    const response = await fetch(`${BASE_URL}/api/books/recommendations`, {
+      headers: { Cookie: 'access_token=invalid-token' },
+    });
+
+    expect(response.status).toBe(401);
+    const body = await response.json() as { success: boolean };
+    expect(body.success).toBe(false);
+  });
+
+  it('should return 200 with items and label when user has history', async () => {
+    getRecommendationsExecute.mockResolvedValueOnce({
+      items: SAMPLE_ITEMS,
+      label: 'Porque te interesa Programación',
+    });
+
+    const response = await fetch(`${BASE_URL}/api/books/recommendations`, {
+      headers: { Cookie: `access_token=${VALID_TOKEN}` },
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as {
+      success: boolean;
+      data: { items: typeof SAMPLE_ITEMS; label: string };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.items).toHaveLength(2);
+    expect(body.data.label).toBe('Porque te interesa Programación');
+    expect(body.data.items[0].bookId).toBe('550e8400-e29b-41d4-a716-446655440000');
+    expect(body.data.items[0].similarity).toBe(0.87);
+
+    expect(getRecommendationsExecute).toHaveBeenCalledWith(VALID_USER_ID);
+  });
+
+  it('should return 200 with empty items when user has no history', async () => {
+    getRecommendationsExecute.mockResolvedValueOnce({
+      items: [],
+      label: '',
+    });
+
+    const response = await fetch(`${BASE_URL}/api/books/recommendations`, {
+      headers: { Cookie: `access_token=${VALID_TOKEN}` },
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as {
+      success: boolean;
+      data: { items: unknown[]; label: string };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.items).toHaveLength(0);
+    expect(body.data.label).toBe('');
+  });
+
+  it('should pass the authenticated userId to the use case', async () => {
+    getRecommendationsExecute.mockClear();
+    getRecommendationsExecute.mockResolvedValueOnce({ items: [], label: '' });
+
+    await fetch(`${BASE_URL}/api/books/recommendations`, {
+      headers: { Cookie: `access_token=${VALID_TOKEN}` },
+    });
+
+    expect(getRecommendationsExecute).toHaveBeenCalledTimes(1);
+    expect(getRecommendationsExecute).toHaveBeenCalledWith(VALID_USER_ID);
+  });
+});

--- a/apps/api/tests/integration/infrastructure/persistence/DrizzleDownloadRepository.integration.test.ts
+++ b/apps/api/tests/integration/infrastructure/persistence/DrizzleDownloadRepository.integration.test.ts
@@ -160,4 +160,72 @@ describe('DrizzleDownloadRepository Integration', () => {
       expect(rows).toHaveLength(1);
     });
   });
+
+  describe('findAllByUser', () => {
+    it('should return empty array when user has no downloads', async () => {
+      const userId = testUser.id as UserId;
+
+      const result = await repository.findAllByUser(userId.value);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return all downloads for a given user', async () => {
+      const userId = testUser.id as UserId;
+
+      // Create a second book
+      const secondBookId = BookId.generate();
+      await insertTestBook(db as any, secondBookId.value, testTypeId);
+
+      // Upsert two downloads for the user
+      const d1 = Download.create(userId, testBookId);
+      const d2 = Download.create(userId, secondBookId);
+      await repository.upsert(d1);
+      await repository.upsert(d2);
+
+      const result = await repository.findAllByUser(userId.value);
+
+      expect(result).toHaveLength(2);
+      const bookIds = result.map(d => d.bookId.value);
+      expect(bookIds).toContain(testBookId.value);
+      expect(bookIds).toContain(secondBookId.value);
+    });
+
+    it('should return only downloads belonging to the requested user', async () => {
+      const userId = testUser.id as UserId;
+
+      // Create a second user
+      const otherUser = User.create({ email: 'other-user@example.com', passwordHash: 'hash' });
+      await userRepository.save(otherUser);
+      const otherUserId = otherUser.id as UserId;
+
+      // Create a second book for the other user
+      const otherBookId = BookId.generate();
+      await insertTestBook(db as any, otherBookId.value, testTypeId);
+
+      // Upsert downloads for both users
+      await repository.upsert(Download.create(userId, testBookId));
+      await repository.upsert(Download.create(otherUserId, otherBookId));
+
+      const result = await repository.findAllByUser(userId.value);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.userId.value).toBe(userId.value);
+      expect(result[0]!.bookId.value).toBe(testBookId.value);
+    });
+
+    it('should return Download domain entities with correct fields', async () => {
+      const userId = testUser.id as UserId;
+      const download = Download.create(userId, testBookId);
+      await repository.upsert(download);
+
+      const result = await repository.findAllByUser(userId.value);
+
+      expect(result).toHaveLength(1);
+      const retrieved = result[0]!;
+      expect(retrieved.userId.value).toBe(userId.value);
+      expect(retrieved.bookId.value).toBe(testBookId.value);
+      expect(retrieved.downloadedAt).toBeInstanceOf(Date);
+    });
+  });
 });

--- a/apps/api/tests/integration/infrastructure/persistence/PostgresBookRepository.integration.test.ts
+++ b/apps/api/tests/integration/infrastructure/persistence/PostgresBookRepository.integration.test.ts
@@ -1324,4 +1324,79 @@ describe('PostgresBookRepository Integration', () => {
       });
     });
   });
+
+  describe('findEmbeddingsByIds', () => {
+    async function saveBookWithEmbedding(title: string, embedding?: number[]): Promise<Book> {
+      const book = Book.create({
+        id: generateUUID(),
+        title,
+        authors: [robertMartin],
+        description: `Description for ${title}`,
+        language: 'en',
+        type: technicalType,
+        format: 'pdf',
+        categories: [programmingCategory],
+      });
+      await bookRepository.save({ book, embedding: embedding ?? generateTestEmbedding() });
+      return book;
+    }
+
+    it('should return empty array when no ids provided', async () => {
+      const result = await bookRepository.findEmbeddingsByIds([]);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return embeddings for existing books with embeddings', async () => {
+      const embedding = generateTestEmbedding();
+      const book = await saveBookWithEmbedding('Book With Embedding', embedding);
+
+      const result = await bookRepository.findEmbeddingsByIds([book.id]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(book.id);
+      expect(Array.isArray(result[0]!.embedding)).toBe(true);
+      expect(result[0]!.embedding).toHaveLength(768);
+    });
+
+    it('should return embeddings for multiple books', async () => {
+      const book1 = await saveBookWithEmbedding('Book One');
+      const book2 = await saveBookWithEmbedding('Book Two');
+
+      const result = await bookRepository.findEmbeddingsByIds([book1.id, book2.id]);
+
+      expect(result).toHaveLength(2);
+      const ids = result.map(r => r.id);
+      expect(ids).toContain(book1.id);
+      expect(ids).toContain(book2.id);
+    });
+
+    it('should not return books that are not in the ids list', async () => {
+      const book1 = await saveBookWithEmbedding('Requested Book');
+      await saveBookWithEmbedding('Other Book');
+
+      const result = await bookRepository.findEmbeddingsByIds([book1.id]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(book1.id);
+    });
+
+    it('should return numeric array embeddings (not strings)', async () => {
+      const embedding = Array.from({ length: 768 }, (_, i) => i / 768);
+      const book = await saveBookWithEmbedding('Typed Embedding Book', embedding);
+
+      const result = await bookRepository.findEmbeddingsByIds([book.id]);
+
+      expect(result).toHaveLength(1);
+      result[0]!.embedding.forEach(v => {
+        expect(typeof v).toBe('number');
+      });
+    });
+
+    it('should return empty array when ids do not match any book', async () => {
+      const result = await bookRepository.findEmbeddingsByIds([generateUUID(), generateUUID()]);
+
+      expect(result).toEqual([]);
+    });
+  });
 });

--- a/apps/api/tests/unit/application/use-cases/GetRecommendationsUseCase.test.ts
+++ b/apps/api/tests/unit/application/use-cases/GetRecommendationsUseCase.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  GetRecommendationsUseCase,
+  type GetRecommendationsUseCaseDeps,
+} from '../../../../src/application/use-cases/GetRecommendationsUseCase.js';
+import type { BookRepository } from '../../../../src/application/ports/BookRepository.js';
+import type { DownloadRepository } from '../../../../src/domain/download/ports/DownloadRepository.js';
+import type { FavoriteRepository } from '../../../../src/domain/favorite/ports/FavoriteRepository.js';
+import { Download } from '../../../../src/domain/download/Download.js';
+import { Book } from '../../../../src/domain/entities/Book.js';
+import { Author } from '../../../../src/domain/entities/Author.js';
+import { BookType } from '../../../../src/domain/entities/BookType.js';
+import { Category } from '../../../../src/domain/entities/Category.js';
+import { UserId } from '../../../../src/domain/user/value-objects/UserId.js';
+import { BookId } from '../../../../src/domain/book/value-objects/BookId.js';
+
+describe('GetRecommendationsUseCase', () => {
+  const userId = '550e8400-e29b-41d4-a716-446655440001';
+  const bookId1 = '550e8400-e29b-41d4-a716-446655440002';
+  const bookId2 = '550e8400-e29b-41d4-a716-446655440003';
+  const bookId3 = '550e8400-e29b-41d4-a716-446655440004';
+  const bookId4 = '550e8400-e29b-41d4-a716-446655440005';
+  const typeId = 'bb0e8400-e29b-41d4-a716-446655440001';
+  const categoryId1 = 'cc0e8400-e29b-41d4-a716-446655440002';
+  const categoryId2 = 'cc0e8400-e29b-41d4-a716-446655440003';
+  const authorId = 'dd0e8400-e29b-41d4-a716-446655440004';
+
+  let mockDownloadRepository: { findAllByUser: ReturnType<typeof vi.fn> };
+  let mockFavoriteRepository: { findAllByUser: ReturnType<typeof vi.fn>; findByUserAndBook: ReturnType<typeof vi.fn>; add: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn> };
+  let mockBookRepository: {
+    findEmbeddingsByIds: ReturnType<typeof vi.fn>;
+    search: ReturnType<typeof vi.fn>;
+    findById: ReturnType<typeof vi.fn>;
+    findByIsbn: ReturnType<typeof vi.fn>;
+    existsByIsbn: ReturnType<typeof vi.fn>;
+    checkDuplicate: ReturnType<typeof vi.fn>;
+    save: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+    findAll: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
+  };
+
+  let useCase: GetRecommendationsUseCase;
+
+  const createTestBook = (id: string, categoryName = 'Programming'): Book =>
+    Book.fromPersistence({
+      id,
+      title: `Book ${id.slice(-4)}`,
+      authors: [Author.create({ id: authorId, name: 'Test Author' })],
+      description: 'desc',
+      originalDescription: 'desc',
+      language: 'en',
+      type: BookType.fromPersistence({ id: typeId, name: 'technical' }),
+      categories: [Category.fromPersistence({ id: categoryId1, name: categoryName, typeId })],
+      format: 'pdf',
+      isbn: null,
+      levelId: null,
+      available: true,
+      path: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+  const createDownload = (bookId: string): Download =>
+    Download.fromPersistence({ userId, bookId, downloadedAt: new Date() });
+
+  beforeEach(() => {
+    mockDownloadRepository = { findAllByUser: vi.fn() };
+    mockFavoriteRepository = {
+      findAllByUser: vi.fn(),
+      findByUserAndBook: vi.fn(),
+      add: vi.fn(),
+      remove: vi.fn(),
+    };
+    mockBookRepository = {
+      findEmbeddingsByIds: vi.fn(),
+      search: vi.fn(),
+      findById: vi.fn(),
+      findByIsbn: vi.fn(),
+      existsByIsbn: vi.fn(),
+      checkDuplicate: vi.fn(),
+      save: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      findAll: vi.fn(),
+      count: vi.fn(),
+    };
+
+    const deps: GetRecommendationsUseCaseDeps = {
+      bookRepository: mockBookRepository as unknown as BookRepository,
+      downloadRepository: mockDownloadRepository as unknown as DownloadRepository,
+      favoriteRepository: mockFavoriteRepository as unknown as FavoriteRepository,
+    };
+    useCase = new GetRecommendationsUseCase(deps);
+  });
+
+  describe('when user has no seeds (no downloads, no favorites)', () => {
+    it('should return empty output', async () => {
+      mockDownloadRepository.findAllByUser.mockResolvedValue([]);
+      mockFavoriteRepository.findAllByUser.mockResolvedValue([]);
+
+      const result = await useCase.execute(userId);
+
+      expect(result).toEqual({ items: [], label: '' });
+      expect(mockBookRepository.findEmbeddingsByIds).not.toHaveBeenCalled();
+      expect(mockBookRepository.search).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when seeds exist but no embeddings found', () => {
+    it('should return empty output', async () => {
+      mockDownloadRepository.findAllByUser.mockResolvedValue([createDownload(bookId1)]);
+      mockFavoriteRepository.findAllByUser.mockResolvedValue([]);
+      mockBookRepository.findEmbeddingsByIds.mockResolvedValue([]);
+
+      const result = await useCase.execute(userId);
+
+      expect(result).toEqual({ items: [], label: '' });
+      expect(mockBookRepository.search).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when seeds and embeddings exist', () => {
+    const centroidEmbedding = [0.5, 0.5];
+    const embedding1 = [1.0, 0.0];
+    const embedding2 = [0.0, 1.0];
+
+    beforeEach(() => {
+      mockDownloadRepository.findAllByUser.mockResolvedValue([createDownload(bookId1)]);
+      mockFavoriteRepository.findAllByUser.mockResolvedValue([BookId.fromPersistence(bookId2)]);
+      mockBookRepository.findEmbeddingsByIds.mockResolvedValue([
+        { id: bookId1, embedding: embedding1 },
+        { id: bookId2, embedding: embedding2 },
+      ]);
+    });
+
+    it('should exclude seed books from recommendations', async () => {
+      const seedBook1 = createTestBook(bookId1);
+      const seedBook2 = createTestBook(bookId2);
+      const candidateBook = createTestBook(bookId3);
+
+      mockBookRepository.search.mockResolvedValue({
+        items: [
+          { book: seedBook1, similarityScore: 0.9, levelName: null },
+          { book: seedBook2, similarityScore: 0.85, levelName: null },
+          { book: candidateBook, similarityScore: 0.8, levelName: null },
+        ],
+        totalCount: 3,
+        hasNextPage: false,
+        nextCursor: null,
+      });
+
+      const result = await useCase.execute(userId);
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].bookId).toBe(bookId3);
+    });
+
+    it('should exclude books with similarity below 0.55 threshold', async () => {
+      const goodBook = createTestBook(bookId3);
+      const badBook = createTestBook(bookId4);
+
+      mockBookRepository.search.mockResolvedValue({
+        items: [
+          { book: goodBook, similarityScore: 0.7, levelName: null },
+          { book: badBook, similarityScore: 0.4, levelName: null },
+        ],
+        totalCount: 2,
+        hasNextPage: false,
+        nextCursor: null,
+      });
+
+      const result = await useCase.execute(userId);
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].bookId).toBe(bookId3);
+      expect(result.items[0].similarity).toBeGreaterThanOrEqual(0.55);
+    });
+
+    it('should return at most top 20 items', async () => {
+      const manyBooks = Array.from({ length: 30 }, (_, i) => ({
+        book: createTestBook(`550e8400-e29b-41d4-a716-${String(i).padStart(12, '0')}`),
+        similarityScore: 0.9 - i * 0.01,
+        levelName: null,
+      }));
+
+      mockBookRepository.search.mockResolvedValue({
+        items: manyBooks,
+        totalCount: 30,
+        hasNextPage: false,
+        nextCursor: null,
+      });
+
+      const result = await useCase.execute(userId);
+
+      expect(result.items.length).toBeLessThanOrEqual(20);
+    });
+
+    it('should build the correct label from dominant category', async () => {
+      const book1 = Book.fromPersistence({
+        id: bookId1,
+        title: 'Book 1',
+        authors: [Author.create({ id: authorId, name: 'Author' })],
+        description: 'desc',
+        originalDescription: 'desc',
+        language: 'en',
+        type: BookType.fromPersistence({ id: typeId, name: 'technical' }),
+        categories: [Category.fromPersistence({ id: categoryId1, name: 'Programming', typeId })],
+        format: 'pdf',
+        isbn: null,
+        levelId: null,
+        available: true,
+        path: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const book2 = Book.fromPersistence({
+        id: bookId2,
+        title: 'Book 2',
+        authors: [Author.create({ id: authorId, name: 'Author' })],
+        description: 'desc',
+        originalDescription: 'desc',
+        language: 'en',
+        type: BookType.fromPersistence({ id: typeId, name: 'technical' }),
+        categories: [Category.fromPersistence({ id: categoryId2, name: 'Programming', typeId })],
+        format: 'pdf',
+        isbn: null,
+        levelId: null,
+        available: true,
+        path: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      mockDownloadRepository.findAllByUser.mockResolvedValue([
+        Download.fromPersistence({ userId, bookId: bookId1, downloadedAt: new Date() }),
+      ]);
+      mockFavoriteRepository.findAllByUser.mockResolvedValue([BookId.fromPersistence(bookId2)]);
+      mockBookRepository.findEmbeddingsByIds.mockResolvedValue([
+        { id: bookId1, embedding: [1.0, 0.0] },
+        { id: bookId2, embedding: [0.0, 1.0] },
+      ]);
+
+      const candidateBook = createTestBook(bookId3);
+      mockBookRepository.search.mockResolvedValue({
+        items: [{ book: candidateBook, similarityScore: 0.8, levelName: null }],
+        totalCount: 1,
+        hasNextPage: false,
+        nextCursor: null,
+      });
+
+      const result = await useCase.execute(userId);
+
+      expect(result.label).toBe('Porque te interesa Programming');
+    });
+
+    it('should deduplicate seeds from downloads and favorites', async () => {
+      // Same book appears in both downloads and favorites
+      mockDownloadRepository.findAllByUser.mockResolvedValue([createDownload(bookId1)]);
+      mockFavoriteRepository.findAllByUser.mockResolvedValue([
+        BookId.fromPersistence(bookId1), // duplicate
+        BookId.fromPersistence(bookId2),
+      ]);
+
+      mockBookRepository.findEmbeddingsByIds.mockResolvedValue([
+        { id: bookId1, embedding: [1.0, 0.0] },
+        { id: bookId2, embedding: [0.0, 1.0] },
+      ]);
+
+      const candidateBook = createTestBook(bookId3);
+      mockBookRepository.search.mockResolvedValue({
+        items: [{ book: candidateBook, similarityScore: 0.8, levelName: null }],
+        totalCount: 1,
+        hasNextPage: false,
+        nextCursor: null,
+      });
+
+      await useCase.execute(userId);
+
+      // Should call findEmbeddingsByIds with deduplicated ids (only 2, not 3)
+      const calledWithIds = mockBookRepository.findEmbeddingsByIds.mock.calls[0][0] as string[];
+      expect(calledWithIds).toHaveLength(2);
+      expect(new Set(calledWithIds).size).toBe(2);
+    });
+
+    it('should map items to RecommendationItem with correct fields', async () => {
+      const candidateBook = createTestBook(bookId3, 'Science');
+      mockBookRepository.search.mockResolvedValue({
+        items: [{ book: candidateBook, similarityScore: 0.75, levelName: null }],
+        totalCount: 1,
+        hasNextPage: false,
+        nextCursor: null,
+      });
+
+      const result = await useCase.execute(userId);
+
+      expect(result.items).toHaveLength(1);
+      const item = result.items[0];
+      expect(item.bookId).toBe(bookId3);
+      expect(item.similarity).toBe(0.75);
+      expect(item.title).toBeTruthy();
+      expect(item.author).toBeTruthy();
+    });
+
+    it('should call search with embedding (centroid) and limit 40', async () => {
+      mockBookRepository.search.mockResolvedValue({
+        items: [],
+        totalCount: 0,
+        hasNextPage: false,
+        nextCursor: null,
+      });
+
+      await useCase.execute(userId);
+
+      expect(mockBookRepository.search).toHaveBeenCalledOnce();
+      const [, embeddingArg] = mockBookRepository.search.mock.calls[0] as [unknown, number[]];
+      expect(embeddingArg).toBeDefined();
+      expect(Array.isArray(embeddingArg)).toBe(true);
+    });
+  });
+
+  describe('when no favoriteRepository is provided', () => {
+    it('should still work using only downloads as seeds', async () => {
+      const depsWithoutFav: GetRecommendationsUseCaseDeps = {
+        bookRepository: mockBookRepository as unknown as BookRepository,
+        downloadRepository: mockDownloadRepository as unknown as DownloadRepository,
+      };
+      const useCaseWithoutFav = new GetRecommendationsUseCase(depsWithoutFav);
+
+      mockDownloadRepository.findAllByUser.mockResolvedValue([createDownload(bookId1)]);
+      mockBookRepository.findEmbeddingsByIds.mockResolvedValue([
+        { id: bookId1, embedding: [1.0, 0.0] },
+      ]);
+
+      const candidateBook = createTestBook(bookId3);
+      mockBookRepository.search.mockResolvedValue({
+        items: [{ book: candidateBook, similarityScore: 0.8, levelName: null }],
+        totalCount: 1,
+        hasNextPage: false,
+        nextCursor: null,
+      });
+
+      const result = await useCaseWithoutFav.execute(userId);
+      expect(result.items).toHaveLength(1);
+    });
+  });
+});

--- a/apps/api/tests/unit/application/use-cases/GetRecommendationsUseCase.test.ts
+++ b/apps/api/tests/unit/application/use-cases/GetRecommendationsUseCase.test.ts
@@ -29,6 +29,7 @@ describe('GetRecommendationsUseCase', () => {
   let mockFavoriteRepository: { findAllByUser: ReturnType<typeof vi.fn>; findByUserAndBook: ReturnType<typeof vi.fn>; add: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn> };
   let mockBookRepository: {
     findEmbeddingsByIds: ReturnType<typeof vi.fn>;
+    findCategoriesByIds: ReturnType<typeof vi.fn>;
     search: ReturnType<typeof vi.fn>;
     findById: ReturnType<typeof vi.fn>;
     findByIsbn: ReturnType<typeof vi.fn>;
@@ -75,6 +76,7 @@ describe('GetRecommendationsUseCase', () => {
     };
     mockBookRepository = {
       findEmbeddingsByIds: vi.fn(),
+      findCategoriesByIds: vi.fn(),
       search: vi.fn(),
       findById: vi.fn(),
       findByIsbn: vi.fn(),
@@ -132,6 +134,10 @@ describe('GetRecommendationsUseCase', () => {
       mockBookRepository.findEmbeddingsByIds.mockResolvedValue([
         { id: bookId1, embedding: embedding1 },
         { id: bookId2, embedding: embedding2 },
+      ]);
+      mockBookRepository.findCategoriesByIds.mockResolvedValue([
+        { id: bookId1, categories: ['Programming'] },
+        { id: bookId2, categories: ['Programming'] },
       ]);
     });
 
@@ -242,6 +248,10 @@ describe('GetRecommendationsUseCase', () => {
         { id: bookId1, embedding: [1.0, 0.0] },
         { id: bookId2, embedding: [0.0, 1.0] },
       ]);
+      mockBookRepository.findCategoriesByIds.mockResolvedValue([
+        { id: bookId1, categories: ['Programming'] },
+        { id: bookId2, categories: ['Programming'] },
+      ]);
 
       const candidateBook = createTestBook(bookId3);
       mockBookRepository.search.mockResolvedValue({
@@ -332,6 +342,9 @@ describe('GetRecommendationsUseCase', () => {
       mockDownloadRepository.findAllByUser.mockResolvedValue([createDownload(bookId1)]);
       mockBookRepository.findEmbeddingsByIds.mockResolvedValue([
         { id: bookId1, embedding: [1.0, 0.0] },
+      ]);
+      mockBookRepository.findCategoriesByIds.mockResolvedValue([
+        { id: bookId1, categories: ['Programming'] },
       ]);
 
       const candidateBook = createTestBook(bookId3);

--- a/apps/api/tests/unit/domain/book/BookRepository.test.ts
+++ b/apps/api/tests/unit/domain/book/BookRepository.test.ts
@@ -1,0 +1,66 @@
+/**
+ * BookRepository Port Contract Tests
+ *
+ * HU-040: Verifies the BookRepository port includes findEmbeddingsByIds method.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { BookRepository } from '../../../../src/application/ports/BookRepository.js';
+
+const BOOK_UUID_1 = '550e8400-e29b-41d4-a716-446655440001';
+const BOOK_UUID_2 = '550e8400-e29b-41d4-a716-446655440002';
+
+describe('BookRepository port', () => {
+  describe('findEmbeddingsByIds', () => {
+    it('should define findEmbeddingsByIds method in the port interface', () => {
+      const mockRepo = {
+        findEmbeddingsByIds: vi.fn().mockResolvedValue([]),
+      } as unknown as BookRepository;
+
+      expect(typeof mockRepo.findEmbeddingsByIds).toBe('function');
+    });
+
+    it('should return embeddings only for books that have non-null embeddings', async () => {
+      const expectedEmbeddings = [
+        { id: BOOK_UUID_1, embedding: [0.1, 0.2, 0.3] },
+        { id: BOOK_UUID_2, embedding: [0.4, 0.5, 0.6] },
+      ];
+
+      const mockRepo = {
+        findEmbeddingsByIds: vi.fn().mockResolvedValue(expectedEmbeddings),
+      } as unknown as BookRepository;
+
+      const result = await mockRepo.findEmbeddingsByIds([BOOK_UUID_1, BOOK_UUID_2]);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ id: BOOK_UUID_1, embedding: [0.1, 0.2, 0.3] });
+      expect(result[1]).toEqual({ id: BOOK_UUID_2, embedding: [0.4, 0.5, 0.6] });
+    });
+
+    it('should return empty array when no book ids are provided', async () => {
+      const mockRepo = {
+        findEmbeddingsByIds: vi.fn().mockResolvedValue([]),
+      } as unknown as BookRepository;
+
+      const result = await mockRepo.findEmbeddingsByIds([]);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should exclude books without embeddings', async () => {
+      // Only BOOK_UUID_1 has an embedding — BOOK_UUID_2 does not
+      const expectedEmbeddings = [
+        { id: BOOK_UUID_1, embedding: [0.1, 0.2, 0.3] },
+      ];
+
+      const mockRepo = {
+        findEmbeddingsByIds: vi.fn().mockResolvedValue(expectedEmbeddings),
+      } as unknown as BookRepository;
+
+      const result = await mockRepo.findEmbeddingsByIds([BOOK_UUID_1, BOOK_UUID_2]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(BOOK_UUID_1);
+    });
+  });
+});

--- a/apps/api/tests/unit/domain/download/DownloadRepository.test.ts
+++ b/apps/api/tests/unit/domain/download/DownloadRepository.test.ts
@@ -1,0 +1,70 @@
+/**
+ * DownloadRepository Port Contract Tests
+ *
+ * HU-040: Verifies the DownloadRepository port includes findAllByUser method.
+ * These are compile-time contract tests — the interface must define the method.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { DownloadRepository } from '../../../../src/domain/download/ports/DownloadRepository.js';
+import { Download } from '../../../../src/domain/download/Download.js';
+import { UserId } from '../../../../src/domain/user/value-objects/UserId.js';
+import { BookId } from '../../../../src/domain/book/value-objects/BookId.js';
+
+const USER_UUID = '550e8400-e29b-41d4-a716-446655440001';
+const BOOK_UUID = '550e8400-e29b-41d4-a716-446655440002';
+
+describe('DownloadRepository port', () => {
+  describe('findAllByUser', () => {
+    it('should define findAllByUser method in the port interface', () => {
+      // Create a mock implementation to verify the interface contract
+      const mockRepo: DownloadRepository = {
+        upsert: vi.fn(),
+        findAllByUser: vi.fn().mockResolvedValue([]),
+      };
+
+      expect(typeof mockRepo.findAllByUser).toBe('function');
+    });
+
+    it('should return an array of Download instances for a given userId', async () => {
+      const download = Download.fromPersistence({
+        userId: USER_UUID,
+        bookId: BOOK_UUID,
+        downloadedAt: new Date('2024-01-01T00:00:00Z'),
+      });
+
+      const mockRepo: DownloadRepository = {
+        upsert: vi.fn(),
+        findAllByUser: vi.fn().mockResolvedValue([download]),
+      };
+
+      const result = await mockRepo.findAllByUser(USER_UUID);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].userId.value).toBe(USER_UUID);
+      expect(result[0].bookId.value).toBe(BOOK_UUID);
+    });
+
+    it('should return empty array when user has no downloads', async () => {
+      const mockRepo: DownloadRepository = {
+        upsert: vi.fn(),
+        findAllByUser: vi.fn().mockResolvedValue([]),
+      };
+
+      const result = await mockRepo.findAllByUser(USER_UUID);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('upsert (existing method)', () => {
+    it('should still define upsert method', () => {
+      const mockRepo: DownloadRepository = {
+        upsert: vi.fn(),
+        findAllByUser: vi.fn().mockResolvedValue([]),
+      };
+
+      expect(typeof mockRepo.upsert).toBe('function');
+    });
+  });
+});

--- a/apps/api/tests/unit/domain/recommendation/RecommendationItem.test.ts
+++ b/apps/api/tests/unit/domain/recommendation/RecommendationItem.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { RecommendationItem } from '../../../../src/domain/recommendation/RecommendationItem.js';
+
+describe('RecommendationItem', () => {
+  const validProps = {
+    bookId: 'book-uuid-123',
+    title: 'Clean Code',
+    author: 'Robert C. Martin',
+    coverUrl: 'https://example.com/cover.jpg',
+    similarity: 0.85,
+    dominantCategory: 'Programming',
+  };
+
+  describe('create()', () => {
+    it('should create a valid RecommendationItem', () => {
+      const item = RecommendationItem.create(validProps);
+      expect(item.bookId).toBe('book-uuid-123');
+      expect(item.title).toBe('Clean Code');
+      expect(item.author).toBe('Robert C. Martin');
+      expect(item.coverUrl).toBe('https://example.com/cover.jpg');
+      expect(item.similarity).toBe(0.85);
+      expect(item.dominantCategory).toBe('Programming');
+    });
+
+    it('should allow coverUrl to be null', () => {
+      const item = RecommendationItem.create({ ...validProps, coverUrl: null });
+      expect(item.coverUrl).toBeNull();
+    });
+
+    it('should accept similarity = 0 (boundary)', () => {
+      const item = RecommendationItem.create({ ...validProps, similarity: 0 });
+      expect(item.similarity).toBe(0);
+    });
+
+    it('should accept similarity = 1 (boundary)', () => {
+      const item = RecommendationItem.create({ ...validProps, similarity: 1 });
+      expect(item.similarity).toBe(1);
+    });
+
+    it('should throw when similarity < 0', () => {
+      expect(() =>
+        RecommendationItem.create({ ...validProps, similarity: -0.1 }),
+      ).toThrow('similarity must be between 0 and 1');
+    });
+
+    it('should throw when similarity > 1', () => {
+      expect(() =>
+        RecommendationItem.create({ ...validProps, similarity: 1.1 }),
+      ).toThrow('similarity must be between 0 and 1');
+    });
+  });
+
+  describe('immutability', () => {
+    it('should be frozen (immutable)', () => {
+      const item = RecommendationItem.create(validProps);
+      expect(Object.isFrozen(item)).toBe(true);
+    });
+  });
+});

--- a/apps/api/tests/unit/domain/recommendation/RecommendationItem.test.ts
+++ b/apps/api/tests/unit/domain/recommendation/RecommendationItem.test.ts
@@ -6,7 +6,6 @@ describe('RecommendationItem', () => {
     bookId: 'book-uuid-123',
     title: 'Clean Code',
     author: 'Robert C. Martin',
-    coverUrl: 'https://example.com/cover.jpg',
     similarity: 0.85,
     dominantCategory: 'Programming',
   };
@@ -17,14 +16,8 @@ describe('RecommendationItem', () => {
       expect(item.bookId).toBe('book-uuid-123');
       expect(item.title).toBe('Clean Code');
       expect(item.author).toBe('Robert C. Martin');
-      expect(item.coverUrl).toBe('https://example.com/cover.jpg');
       expect(item.similarity).toBe(0.85);
       expect(item.dominantCategory).toBe('Programming');
-    });
-
-    it('should allow coverUrl to be null', () => {
-      const item = RecommendationItem.create({ ...validProps, coverUrl: null });
-      expect(item.coverUrl).toBeNull();
     });
 
     it('should accept similarity = 0 (boundary)', () => {

--- a/apps/api/tests/unit/domain/recommendation/centroid.test.ts
+++ b/apps/api/tests/unit/domain/recommendation/centroid.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { computeCentroid } from '../../../../src/domain/recommendation/centroid.js';
+
+describe('computeCentroid', () => {
+  it('should compute the average of a single embedding', () => {
+    const result = computeCentroid([[1, 2, 3]]);
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  it('should compute the element-wise average of multiple embeddings', () => {
+    const result = computeCentroid([
+      [1, 0, 0],
+      [0, 1, 0],
+      [0, 0, 1],
+    ]);
+    expect(result[0]).toBeCloseTo(1 / 3);
+    expect(result[1]).toBeCloseTo(1 / 3);
+    expect(result[2]).toBeCloseTo(1 / 3);
+  });
+
+  it('should handle negative values', () => {
+    const result = computeCentroid([
+      [2, -2],
+      [-2, 2],
+    ]);
+    expect(result).toEqual([0, 0]);
+  });
+
+  it('should throw DomainError when embeddings array is empty', () => {
+    expect(() => computeCentroid([])).toThrow('embeddings cannot be empty');
+  });
+
+  it('should return an array of the same length as the input embeddings', () => {
+    const dims = 1536;
+    const emb = Array.from({ length: dims }, () => Math.random());
+    const result = computeCentroid([emb, emb]);
+    expect(result).toHaveLength(dims);
+  });
+});

--- a/apps/api/tests/unit/domain/recommendation/dominantCategory.test.ts
+++ b/apps/api/tests/unit/domain/recommendation/dominantCategory.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { getDominantCategory } from '../../../../src/domain/recommendation/dominantCategory.js';
+
+describe('getDominantCategory', () => {
+  it('should return the most frequent category', () => {
+    const result = getDominantCategory([
+      'Programming',
+      'Programming',
+      'Design',
+    ]);
+    expect(result).toBe('Programming');
+  });
+
+  it('should return the first-appearing on tie', () => {
+    const result = getDominantCategory(['Design', 'Programming', 'Design', 'Programming']);
+    expect(result).toBe('Design');
+  });
+
+  it('should return the only category if there is just one', () => {
+    const result = getDominantCategory(['Mathematics']);
+    expect(result).toBe('Mathematics');
+  });
+
+  it('should return "General" when the array is empty', () => {
+    const result = getDominantCategory([]);
+    expect(result).toBe('General');
+  });
+
+  it('should handle a tie where first appearance wins', () => {
+    const result = getDominantCategory(['A', 'B', 'A', 'B', 'C']);
+    expect(result).toBe('A');
+  });
+});

--- a/apps/web-client/src/app/app.routes.ts
+++ b/apps/web-client/src/app/app.routes.ts
@@ -1,6 +1,19 @@
 import { Routes } from '@angular/router';
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
 import { MainLayoutComponent } from '@layout/main-layout/main-layout.component.js';
 import { ResetPasswordPageComponent } from './auth/reset-password/index.js';
+import { AuthService } from './auth/auth.service.js';
+
+/**
+ * Guard: allows access only when the user is authenticated.
+ * Redirects to /books if not logged in.
+ */
+const authGuard = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  return auth.currentUser() !== null ? true : router.createUrlTree(['/books']);
+};
 
 /**
  * Application Routes
@@ -24,6 +37,16 @@ export const routes: Routes = [
       {
         path: 'books',
         loadChildren: () => import('./catalog/catalog.routes.js').then((m) => m.catalogRoutes),
+      },
+      // Personalised recommendations (auth required)
+      {
+        path: 'recomendaciones',
+        loadComponent: () =>
+          import('./recommendations/feature/recommendations-page.component.js').then(
+            (m) => m.RecommendationsPageComponent
+          ),
+        canActivate: [authGuard],
+        title: 'Para ti',
       },
       // Password reset page
       {

--- a/apps/web-client/src/app/app.routes.ts
+++ b/apps/web-client/src/app/app.routes.ts
@@ -40,7 +40,7 @@ export const routes: Routes = [
       },
       // Personalised recommendations (auth required)
       {
-        path: 'recomendaciones',
+        path: 'recommendations',
         loadComponent: () =>
           import('./recommendations/feature/recommendations-page.component.js').then(
             (m) => m.RecommendationsPageComponent

--- a/apps/web-client/src/app/auth/auth.service.ts
+++ b/apps/web-client/src/app/auth/auth.service.ts
@@ -39,7 +39,7 @@ export class AuthService {
       catchError(() => {
         this._currentUser.set(null);
         return of(undefined as any);
-      }),
+      })
     );
   }
 
@@ -51,9 +51,9 @@ export class AuthService {
    * @param password - User password
    */
   login(email: string, password: string): Observable<void> {
-    return this.api.post<void>('/auth/login', { email, password }).pipe(
-      tap(() => this._currentUser.set({ email }))
-    );
+    return this.api
+      .post<void>('/auth/login', { email, password })
+      .pipe(tap(() => this._currentUser.set({ email })));
   }
 
   /**
@@ -61,9 +61,7 @@ export class AuthService {
    * On success, clears the currentUser signal.
    */
   logout(): Observable<void> {
-    return this.api.post<void>('/auth/logout', {}).pipe(
-      tap(() => this._currentUser.set(null))
-    );
+    return this.api.post<void>('/auth/logout', {}).pipe(tap(() => this._currentUser.set(null)));
   }
 
   /**
@@ -73,7 +71,7 @@ export class AuthService {
   refreshToken(): Observable<boolean> {
     return this.api.post<void>('/auth/refresh', {}).pipe(
       tap(() => {}),
-      catchError(() => of(false as any)),
+      catchError(() => of(false as any))
     );
   }
 
@@ -104,4 +102,3 @@ export class AuthService {
     return this.api.post<void>('/auth/reset-password', { token, newPassword });
   }
 }
-

--- a/apps/web-client/src/app/auth/login-modal/login-modal.component.spec.ts
+++ b/apps/web-client/src/app/auth/login-modal/login-modal.component.spec.ts
@@ -24,10 +24,7 @@ describe('LoginModalComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [LoginModalComponent],
-      providers: [
-        provideRouter([]),
-        { provide: AuthService, useValue: authServiceMock },
-      ],
+      providers: [provideRouter([]), { provide: AuthService, useValue: authServiceMock }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LoginModalComponent);

--- a/apps/web-client/src/app/auth/login-modal/login-modal.component.ts
+++ b/apps/web-client/src/app/auth/login-modal/login-modal.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  inject,
-  signal,
-  OnDestroy,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, signal, OnDestroy } from '@angular/core';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { DialogRef } from '@angular/cdk/dialog';
@@ -32,22 +26,13 @@ import { AuthService } from '../auth.service.js';
       <!-- Header -->
       <div class="login-modal__header">
         <h2 id="login-modal-title" class="login-modal__title">Iniciar sesión</h2>
-        <button
-          class="login-modal__close"
-          aria-label="Cerrar"
-          (click)="close()"
-        >
+        <button class="login-modal__close" aria-label="Cerrar" (click)="close()">
           <span class="material-symbols-outlined">close</span>
         </button>
       </div>
 
       <!-- Form -->
-      <form
-        class="login-modal__form"
-        [formGroup]="form"
-        (ngSubmit)="submit()"
-        novalidate
-      >
+      <form class="login-modal__form" [formGroup]="form" (ngSubmit)="submit()" novalidate>
         <!-- Email field -->
         <div class="login-modal__field">
           <label for="login-email" class="login-modal__label">Email</label>
@@ -84,9 +69,7 @@ import { AuthService } from '../auth.service.js';
             autocomplete="current-password"
           />
           @if (passwordHasError()) {
-            <span class="login-modal__error" role="alert">
-              La contraseña es obligatoria.
-            </span>
+            <span class="login-modal__error" role="alert"> La contraseña es obligatoria. </span>
           }
         </div>
 
@@ -99,11 +82,7 @@ import { AuthService } from '../auth.service.js';
         }
 
         <!-- Submit -->
-        <button
-          type="submit"
-          class="login-modal__submit"
-          [disabled]="isLoading()"
-        >
+        <button type="submit" class="login-modal__submit" [disabled]="isLoading()">
           @if (isLoading()) {
             <span class="material-symbols-outlined login-modal__spinner">sync</span>
             Iniciando sesión...

--- a/apps/web-client/src/app/auth/reset-password/reset-password-page.component.ts
+++ b/apps/web-client/src/app/auth/reset-password/reset-password-page.component.ts
@@ -74,7 +74,6 @@ function passwordsMatchValidator(control: AbstractControl): ValidationErrors | n
         <!-- Form -->
         @if (token && !isSuccess()) {
           <form class="rp-form" [formGroup]="form" (ngSubmit)="submit()" novalidate>
-
             <!-- New password field -->
             <div class="rp-field">
               <label for="rp-password" class="rp-label">Nueva contraseña</label>
@@ -402,9 +401,7 @@ export class ResetPasswordPageComponent implements OnInit, OnDestroy {
       error: (err: { status?: number }) => {
         this.isLoading.set(false);
         if (err?.status === 400 || err?.status === 401 || err?.status === 404) {
-          this.serverError.set(
-            'El enlace ha expirado o ya fue utilizado. Solicitá uno nuevo.'
-          );
+          this.serverError.set('El enlace ha expirado o ya fue utilizado. Solicitá uno nuevo.');
         } else {
           this.serverError.set('Ha ocurrido un error. Intentalo de nuevo.');
         }

--- a/apps/web-client/src/app/catalog/components/filters/filter-panel/filter-panel.component.ts
+++ b/apps/web-client/src/app/catalog/components/filters/filter-panel/filter-panel.component.ts
@@ -198,10 +198,7 @@ const DEFAULT_FILTERS: FilterState = {
           <section class="filter-section">
             <h3 class="filter-section__title">Mi biblioteca</h3>
 
-            <label
-              class="favorites-checkbox-label"
-              data-testid="favorites-filter"
-            >
+            <label class="favorites-checkbox-label" data-testid="favorites-filter">
               <input
                 type="checkbox"
                 class="favorites-checkbox"

--- a/apps/web-client/src/app/catalog/components/table/book-card/book-card.component.ts
+++ b/apps/web-client/src/app/catalog/components/table/book-card/book-card.component.ts
@@ -1,4 +1,12 @@
-import { ChangeDetectionStrategy, Component, computed, inject, input, output, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core';
 import { CategoryChipsComponent } from '../../data-display/category-chips/category-chips.component.js';
 import { LevelBadgeComponent } from '../../data-display/level-badge/level-badge.component.js';
 import { FormatIconComponent } from '../../data-display/format-icon/format-icon.component.js';
@@ -46,7 +54,9 @@ import { FavoriteService } from '../../../../books/services/favorite.service.js'
             </button>
             <button
               type="button"
-              [attr.aria-label]="getEffectiveFavorite() ? 'Quitar de favoritos' : 'Añadir a favoritos'"
+              [attr.aria-label]="
+                getEffectiveFavorite() ? 'Quitar de favoritos' : 'Añadir a favoritos'
+              "
               class="book-card-action"
               [class.favorite-active]="getEffectiveFavorite()"
               [disabled]="pendingFavorite()"

--- a/apps/web-client/src/app/core/interceptors/auth.interceptor.ts
+++ b/apps/web-client/src/app/core/interceptors/auth.interceptor.ts
@@ -25,7 +25,7 @@ import { AuthService } from '../../auth/auth.service.js';
  */
 export const authInterceptor: HttpInterceptorFn = (
   req: HttpRequest<unknown>,
-  next: HttpHandlerFn,
+  next: HttpHandlerFn
 ) => {
   const authService = inject(AuthService);
 
@@ -55,8 +55,8 @@ export const authInterceptor: HttpInterceptorFn = (
         catchError((refreshError: unknown) => {
           authService.clearSession();
           return throwError(() => refreshError);
-        }),
+        })
       );
-    }),
+    })
   );
 };

--- a/apps/web-client/src/app/core/services/kindle.service.spec.ts
+++ b/apps/web-client/src/app/core/services/kindle.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { firstValueFrom, of, throwError } from 'rxjs';
 
-import { KindleService, SendToKindleResult } from './kindle.service.js';
+import { KindleService } from './kindle.service.js';
 import { BookService } from './book.service.js';
 import { Book } from '../models/index.js';
 

--- a/apps/web-client/src/app/core/services/kindle.service.spec.ts
+++ b/apps/web-client/src/app/core/services/kindle.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { of, throwError } from 'rxjs';
+import { firstValueFrom, of, throwError } from 'rxjs';
 
 import { KindleService, SendToKindleResult } from './kindle.service.js';
 import { BookService } from './book.service.js';
@@ -44,15 +44,13 @@ describe('KindleService', () => {
   });
 
   describe('sendToKindle', () => {
-    it('should return success result when API call succeeds', (done) => {
+    it('should return success result when API call succeeds', async () => {
       mockBookService.sendBookByEmail.mockReturnValue(of(undefined));
 
-      service.sendToKindle(mockBook, 'test@kindle.com').subscribe((result: SendToKindleResult) => {
-        expect(result.success).toBe(true);
-        expect(result.message).toContain('Clean Code');
-        expect(result.message).toContain('test@kindle.com');
-        done();
-      });
+      const result = await firstValueFrom(service.sendToKindle(mockBook, 'test@kindle.com'));
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('Clean Code');
+      expect(result.message).toContain('test@kindle.com');
     });
 
     it('should call BookService.sendBookByEmail with correct arguments', () => {
@@ -66,26 +64,22 @@ describe('KindleService', () => {
       );
     });
 
-    it('should return error result when API call fails', (done) => {
+    it('should return error result when API call fails', async () => {
       mockBookService.sendBookByEmail.mockReturnValue(throwError(() => new Error('Network error')));
 
-      service.sendToKindle(mockBook, 'test@kindle.com').subscribe((result: SendToKindleResult) => {
-        expect(result.success).toBe(false);
-        expect(result.message).toContain('Error al enviar');
-        done();
-      });
+      const result = await firstValueFrom(service.sendToKindle(mockBook, 'test@kindle.com'));
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Error al enviar');
     });
 
-    it('should return error result when API returns HTTP error', (done) => {
+    it('should return error result when API returns HTTP error', async () => {
       mockBookService.sendBookByEmail.mockReturnValue(
         throwError(() => ({ status: 404, message: 'Book not found' }))
       );
 
-      service.sendToKindle(mockBook, 'test@gmail.com').subscribe((result: SendToKindleResult) => {
-        expect(result.success).toBe(false);
-        expect(result.message).toBeTruthy();
-        done();
-      });
+      const result = await firstValueFrom(service.sendToKindle(mockBook, 'test@gmail.com'));
+      expect(result.success).toBe(false);
+      expect(result.message).toBeTruthy();
     });
   });
 

--- a/apps/web-client/src/app/layout/header/header.component.ts
+++ b/apps/web-client/src/app/layout/header/header.component.ts
@@ -34,7 +34,7 @@ import { LoginModalComponent } from '../../auth/login-modal/login-modal.componen
         <nav class="header__nav" aria-label="Navegación principal">
           <a
             class="header__nav-link"
-            routerLink="/recomendaciones"
+            routerLink="/recommendations"
             routerLinkActive="header__nav-link--active"
             aria-label="Para ti — recomendaciones personalizadas"
           >

--- a/apps/web-client/src/app/layout/header/header.component.ts
+++ b/apps/web-client/src/app/layout/header/header.component.ts
@@ -1,4 +1,5 @@
 import { Component, ChangeDetectionStrategy, inject, signal } from '@angular/core';
+import { RouterLink, RouterLinkActive } from '@angular/router';
 import { Dialog } from '@angular/cdk/dialog';
 
 import { ThemeToggleComponent } from '@shared/components/theme-toggle';
@@ -18,7 +19,7 @@ import { LoginModalComponent } from '../../auth/login-modal/login-modal.componen
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [ThemeToggleComponent],
+  imports: [ThemeToggleComponent, RouterLink, RouterLinkActive],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <header class="header">
@@ -28,6 +29,22 @@ import { LoginModalComponent } from '../../auth/login-modal/login-modal.componen
         </div>
         <span class="header__title">BiblioManager</span>
       </div>
+
+      @if (authService.currentUser() !== null) {
+        <nav class="header__nav" aria-label="Navegación principal">
+          <a
+            class="header__nav-link"
+            routerLink="/recomendaciones"
+            routerLinkActive="header__nav-link--active"
+            aria-label="Para ti — recomendaciones personalizadas"
+          >
+            <span class="material-symbols-outlined header__nav-icon" aria-hidden="true"
+              >recommend</span
+            >
+            Para ti
+          </a>
+        </nav>
+      }
 
       <div class="header__actions">
         <app-theme-toggle />
@@ -46,16 +63,21 @@ import { LoginModalComponent } from '../../auth/login-modal/login-modal.componen
           </div>
         } @else {
           <!-- Authenticated: show user menu -->
-          <div class="header__user" (click)="toggleDropdown()" (keydown.enter)="toggleDropdown()" role="button" tabindex="0" aria-label="Menú de usuario" aria-haspopup="true" [attr.aria-expanded]="isDropdownOpen()">
+          <div
+            class="header__user"
+            (click)="toggleDropdown()"
+            (keydown.enter)="toggleDropdown()"
+            role="button"
+            tabindex="0"
+            aria-label="Menú de usuario"
+            aria-haspopup="true"
+            [attr.aria-expanded]="isDropdownOpen()"
+          >
             <span class="header__email">{{ authService.currentUser()!.email }}</span>
             <span class="material-symbols-outlined header__user-icon">account_circle</span>
             @if (isDropdownOpen()) {
               <div class="header__dropdown" role="menu">
-                <button
-                  class="header__dropdown-item"
-                  role="menuitem"
-                  (click)="logout($event)"
-                >
+                <button class="header__dropdown-item" role="menuitem" (click)="logout($event)">
                   <span class="material-symbols-outlined">logout</span>
                   Desconectarse
                 </button>
@@ -136,6 +158,75 @@ import { LoginModalComponent } from '../../auth/login-modal/login-modal.componen
         align-items: center;
         gap: 1rem;
         flex-shrink: 0;
+      }
+
+      /* Navigation links */
+      .header__nav {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+        flex: 1;
+        padding-left: 1.5rem;
+      }
+
+      .header__nav-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.375rem 0.75rem;
+        border-radius: 0.5rem;
+        font-size: 0.875rem;
+        font-weight: 500;
+        text-decoration: none;
+        transition:
+          background-color 150ms ease,
+          color 150ms ease;
+
+        [data-theme='dark'] & {
+          color: rgb(148 163 184);
+
+          &:hover {
+            background-color: rgb(30 41 59);
+            color: rgb(203 213 225);
+          }
+        }
+
+        [data-theme='light'] & {
+          color: rgb(71 85 105);
+
+          &:hover {
+            background-color: rgb(241 245 249);
+            color: rgb(15 23 42);
+          }
+        }
+
+        &:focus-visible {
+          outline: 2px solid #17a1cf;
+          outline-offset: 2px;
+        }
+      }
+
+      .header__nav-link--active {
+        [data-theme='dark'] & {
+          background-color: rgb(30 41 59);
+          color: rgb(23 161 207);
+        }
+
+        [data-theme='light'] & {
+          background-color: rgb(239 248 252);
+          color: #17a1cf;
+        }
+      }
+
+      .header__nav-icon {
+        font-size: 18px;
+        width: 18px;
+        height: 18px;
+        font-variation-settings:
+          'FILL' 0,
+          'wght' 400,
+          'GRAD' 0,
+          'opsz' 18;
       }
 
       /* Unauthenticated avatar */

--- a/apps/web-client/src/app/recommendations/data-access/recommendations.service.spec.ts
+++ b/apps/web-client/src/app/recommendations/data-access/recommendations.service.spec.ts
@@ -1,0 +1,103 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
+
+import { RecommendationsService, RecommendationsResponse } from './recommendations.service.js';
+import { ApiService } from '../../core/services/api.service.js';
+
+describe('RecommendationsService', () => {
+  let service: RecommendationsService;
+  let apiServiceMock: { get: ReturnType<typeof vi.fn> };
+
+  const mockResponse: RecommendationsResponse = {
+    label: 'Programación',
+    items: [
+      {
+        bookId: 'book-1',
+        title: 'Clean Code',
+        author: 'Robert C. Martin',
+        coverUrl: 'https://example.com/cover.jpg',
+        similarity: 0.95,
+        dominantCategory: 'Programación',
+      },
+      {
+        bookId: 'book-2',
+        title: 'The Pragmatic Programmer',
+        author: 'David Thomas',
+        coverUrl: null,
+        similarity: 0.88,
+        dominantCategory: 'Programación',
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    apiServiceMock = {
+      get: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [RecommendationsService, { provide: ApiService, useValue: apiServiceMock }],
+    });
+
+    service = TestBed.inject(RecommendationsService);
+  });
+
+  describe('Creation', () => {
+    it('should create', () => {
+      expect(service).toBeTruthy();
+    });
+  });
+
+  describe('getRecommendations', () => {
+    it('should call GET /books/recommendations', async () => {
+      apiServiceMock.get.mockReturnValue(of(mockResponse));
+
+      await firstValueFrom(service.getRecommendations());
+
+      expect(apiServiceMock.get).toHaveBeenCalledWith('/books/recommendations');
+    });
+
+    it('should return the recommendations response', async () => {
+      apiServiceMock.get.mockReturnValue(of(mockResponse));
+
+      const result = await firstValueFrom(service.getRecommendations());
+
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should return items array from response', async () => {
+      apiServiceMock.get.mockReturnValue(of(mockResponse));
+
+      const result = await firstValueFrom(service.getRecommendations());
+
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].bookId).toBe('book-1');
+    });
+
+    it('should handle items with null coverUrl', async () => {
+      apiServiceMock.get.mockReturnValue(of(mockResponse));
+
+      const result = await firstValueFrom(service.getRecommendations());
+
+      expect(result.items[1].coverUrl).toBeNull();
+    });
+
+    it('should return the category label', async () => {
+      apiServiceMock.get.mockReturnValue(of(mockResponse));
+
+      const result = await firstValueFrom(service.getRecommendations());
+
+      expect(result.label).toBe('Programación');
+    });
+
+    it('should handle empty items array', async () => {
+      const emptyResponse: RecommendationsResponse = { label: '', items: [] };
+      apiServiceMock.get.mockReturnValue(of(emptyResponse));
+
+      const result = await firstValueFrom(service.getRecommendations());
+
+      expect(result.items).toHaveLength(0);
+    });
+  });
+});

--- a/apps/web-client/src/app/recommendations/data-access/recommendations.service.ts
+++ b/apps/web-client/src/app/recommendations/data-access/recommendations.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ApiService } from '../../core/services/api.service.js';
+
+/**
+ * A single recommendation item returned by the API
+ */
+export interface RecommendationItem {
+  bookId: string;
+  title: string;
+  author: string;
+  coverUrl: string | null;
+  similarity: number;
+  dominantCategory: string;
+}
+
+/**
+ * Full recommendations response from the API
+ */
+export interface RecommendationsResponse {
+  items: RecommendationItem[];
+  label: string;
+}
+
+/**
+ * RecommendationsService - Fetches personalised book recommendations
+ *
+ * Wraps GET /api/books/recommendations and returns the typed response.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class RecommendationsService {
+  private readonly api = inject(ApiService);
+
+  /**
+   * Retrieve personalised recommendations for the current user.
+   *
+   * @returns Observable of RecommendationsResponse
+   */
+  getRecommendations(): Observable<RecommendationsResponse> {
+    return this.api.get<RecommendationsResponse>('/books/recommendations');
+  }
+}

--- a/apps/web-client/src/app/recommendations/feature/recommendations-page.component.spec.ts
+++ b/apps/web-client/src/app/recommendations/feature/recommendations-page.component.spec.ts
@@ -1,0 +1,217 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of, throwError } from 'rxjs';
+
+import { RecommendationsPageComponent } from './recommendations-page.component.js';
+import {
+  RecommendationsService,
+  RecommendationsResponse,
+} from '../data-access/recommendations.service.js';
+
+describe('RecommendationsPageComponent', () => {
+  let component: RecommendationsPageComponent;
+  let fixture: ComponentFixture<RecommendationsPageComponent>;
+  let mockService: { getRecommendations: ReturnType<typeof vi.fn> };
+
+  const mockResponse: RecommendationsResponse = {
+    label: 'Programación',
+    items: [
+      {
+        bookId: 'book-1',
+        title: 'Clean Code',
+        author: 'Robert C. Martin',
+        coverUrl: 'https://example.com/cover.jpg',
+        similarity: 0.95,
+        dominantCategory: 'Programación',
+      },
+      {
+        bookId: 'book-2',
+        title: 'The Pragmatic Programmer',
+        author: 'David Thomas',
+        coverUrl: null,
+        similarity: 0.88,
+        dominantCategory: 'Programación',
+      },
+    ],
+  };
+
+  const emptyResponse: RecommendationsResponse = { label: '', items: [] };
+
+  beforeEach(async () => {
+    mockService = {
+      getRecommendations: vi.fn().mockReturnValue(of(mockResponse)),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [RecommendationsPageComponent, RouterTestingModule],
+      providers: [{ provide: RecommendationsService, useValue: mockService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RecommendationsPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe('Creation', () => {
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+  });
+
+  describe('Initialization', () => {
+    it('should call getRecommendations on init', () => {
+      expect(mockService.getRecommendations).toHaveBeenCalled();
+    });
+
+    it('should set loading to false after data loads', () => {
+      expect(component.loading()).toBe(false);
+    });
+
+    it('should populate items after successful load', () => {
+      expect(component.items()).toHaveLength(2);
+    });
+
+    it('should set the category label', () => {
+      expect(component.label()).toBe('Programación');
+    });
+  });
+
+  describe('Layout with data', () => {
+    it('should render the page title "Para ti"', () => {
+      const title = fixture.nativeElement.querySelector('.recommendations-title');
+      expect(title?.textContent?.trim()).toBe('Para ti');
+    });
+
+    it('should render the category label', () => {
+      const label = fixture.nativeElement.querySelector('.recommendations-label');
+      expect(label?.textContent).toContain('Programación');
+    });
+
+    it('should render a card for each recommendation', () => {
+      const cards = fixture.nativeElement.querySelectorAll('.book-card');
+      expect(cards.length).toBe(2);
+    });
+
+    it('should render book titles', () => {
+      const titles = fixture.nativeElement.querySelectorAll('.book-card__title');
+      expect(titles[0].textContent.trim()).toBe('Clean Code');
+    });
+
+    it('should render book authors', () => {
+      const authors = fixture.nativeElement.querySelectorAll('.book-card__author');
+      expect(authors[0].textContent.trim()).toBe('Robert C. Martin');
+    });
+
+    it('should render cover image when coverUrl is present', () => {
+      const img = fixture.nativeElement.querySelector('.book-card__img');
+      expect(img).toBeTruthy();
+      expect(img.getAttribute('src')).toBe('https://example.com/cover.jpg');
+    });
+
+    it('should render cover placeholder when coverUrl is null', () => {
+      const cards = fixture.nativeElement.querySelectorAll('.book-card');
+      const placeholder = cards[1].querySelector('.book-card__cover-placeholder');
+      expect(placeholder).toBeTruthy();
+    });
+
+    it('should show similarity percentage badge', () => {
+      const badges = fixture.nativeElement.querySelectorAll('.book-card__similarity');
+      expect(badges[0].textContent.trim()).toBe('95%');
+    });
+  });
+
+  describe('Empty state', () => {
+    beforeEach(() => {
+      mockService.getRecommendations.mockReturnValue(of(emptyResponse));
+      component.load();
+      fixture.detectChanges();
+    });
+
+    it('should render the empty-state element', () => {
+      const empty = fixture.nativeElement.querySelector('[data-testid="empty-state"]');
+      expect(empty).toBeTruthy();
+    });
+
+    it('should show the no-history message', () => {
+      const msg = fixture.nativeElement.querySelector('.empty-message');
+      expect(msg?.textContent).toContain('suficiente historial');
+    });
+
+    it('should NOT render any book cards', () => {
+      const cards = fixture.nativeElement.querySelectorAll('.book-card');
+      expect(cards.length).toBe(0);
+    });
+  });
+
+  describe('Error state', () => {
+    beforeEach(() => {
+      mockService.getRecommendations.mockReturnValue(throwError(() => new Error('500')));
+      component.load();
+      fixture.detectChanges();
+    });
+
+    it('should render the error-state element', () => {
+      const error = fixture.nativeElement.querySelector('[data-testid="error-state"]');
+      expect(error).toBeTruthy();
+    });
+
+    it('should set error signal to true', () => {
+      expect(component.error()).toBe(true);
+    });
+
+    it('should show a retry button', () => {
+      const btn = fixture.nativeElement.querySelector('[data-testid="error-state"] .btn-primary');
+      expect(btn).toBeTruthy();
+    });
+  });
+
+  describe('Loading state', () => {
+    it('should show skeleton cards while loading', () => {
+      component.loading.set(true);
+      fixture.detectChanges();
+
+      const skeletons = fixture.nativeElement.querySelectorAll('.book-card--skeleton');
+      expect(skeletons.length).toBeGreaterThan(0);
+    });
+
+    it('should NOT show skeleton cards after loading completes', () => {
+      // loading is false after detectChanges in beforeEach
+      const skeletons = fixture.nativeElement.querySelectorAll('.book-card--skeleton');
+      expect(skeletons.length).toBe(0);
+    });
+  });
+
+  describe('similarityPercent', () => {
+    it('should convert 0.95 to 95', () => {
+      expect(component.similarityPercent(0.95)).toBe(95);
+    });
+
+    it('should convert 0.5 to 50', () => {
+      expect(component.similarityPercent(0.5)).toBe(50);
+    });
+
+    it('should round 0.876 to 88', () => {
+      expect(component.similarityPercent(0.876)).toBe(88);
+    });
+
+    it('should convert 1 to 100', () => {
+      expect(component.similarityPercent(1)).toBe(100);
+    });
+
+    it('should convert 0 to 0', () => {
+      expect(component.similarityPercent(0)).toBe(0);
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have role="list" on the grid when there are items', () => {
+      const grid = fixture.nativeElement.querySelector('.recommendations-grid[role="list"]');
+      expect(grid).toBeTruthy();
+    });
+
+    it('should have role="listitem" on each book card', () => {
+      const listItems = fixture.nativeElement.querySelectorAll('[role="listitem"]');
+      expect(listItems.length).toBe(2);
+    });
+  });
+});

--- a/apps/web-client/src/app/recommendations/feature/recommendations-page.component.ts
+++ b/apps/web-client/src/app/recommendations/feature/recommendations-page.component.ts
@@ -1,4 +1,12 @@
-import { Component, ChangeDetectionStrategy, inject, signal, OnInit } from '@angular/core';
+import {
+  Component,
+  ChangeDetectionStrategy,
+  inject,
+  signal,
+  OnInit,
+  DestroyRef,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { catchError, of } from 'rxjs';
 
@@ -28,7 +36,7 @@ import {
         @if (!loading() && label()) {
           <p class="recommendations-label">
             <span class="material-symbols-outlined label-icon" aria-hidden="true">category</span>
-            Basado en tu interés por <strong>{{ label() }}</strong>
+            {{ label() }}
           </p>
         }
       </div>
@@ -76,18 +84,9 @@ import {
               [attr.aria-label]="item.title + ' de ' + item.author"
             >
               <div class="book-card__cover">
-                @if (item.coverUrl) {
-                  <img
-                    [src]="item.coverUrl"
-                    [alt]="'Portada de ' + item.title"
-                    class="book-card__img"
-                    loading="lazy"
-                  />
-                } @else {
-                  <div class="book-card__cover-placeholder" aria-hidden="true">
-                    <span class="material-symbols-outlined">book</span>
-                  </div>
-                }
+                <div class="book-card__cover-placeholder" aria-hidden="true">
+                  <span class="material-symbols-outlined">book</span>
+                </div>
                 <div
                   class="book-card__similarity"
                   [attr.aria-label]="'Similitud ' + similarityPercent(item.similarity) + '%'"
@@ -476,6 +475,7 @@ import {
 })
 export class RecommendationsPageComponent implements OnInit {
   private readonly recommendationsService = inject(RecommendationsService);
+  private readonly destroyRef = inject(DestroyRef);
 
   readonly loading = signal(true);
   readonly error = signal(false);
@@ -495,7 +495,10 @@ export class RecommendationsPageComponent implements OnInit {
 
     this.recommendationsService
       .getRecommendations()
-      .pipe(catchError(() => of(null)))
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        catchError(() => of(null))
+      )
       .subscribe((response) => {
         if (response === null) {
           this.error.set(true);

--- a/apps/web-client/src/app/recommendations/feature/recommendations-page.component.ts
+++ b/apps/web-client/src/app/recommendations/feature/recommendations-page.component.ts
@@ -1,0 +1,514 @@
+import { Component, ChangeDetectionStrategy, inject, signal, OnInit } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { catchError, of } from 'rxjs';
+
+import {
+  RecommendationsService,
+  RecommendationItem,
+} from '../data-access/recommendations.service.js';
+
+/**
+ * RecommendationsPageComponent - "Para ti" personalised recommendations page
+ *
+ * Features:
+ * - Fetches recommendations from GET /api/books/recommendations
+ * - Shows loading skeleton while fetching
+ * - Shows empty state when there is no history yet
+ * - Shows a grid of recommended book cards with cover, title, author and link
+ */
+@Component({
+  selector: 'app-recommendations-page',
+  standalone: true,
+  imports: [RouterLink],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="recommendations-page">
+      <div class="recommendations-header">
+        <h1 class="recommendations-title">Para ti</h1>
+        @if (!loading() && label()) {
+          <p class="recommendations-label">
+            <span class="material-symbols-outlined label-icon" aria-hidden="true">category</span>
+            Basado en tu interés por <strong>{{ label() }}</strong>
+          </p>
+        }
+      </div>
+
+      @if (loading()) {
+        <!-- Loading skeleton -->
+        <div class="recommendations-grid" aria-busy="true" aria-label="Cargando recomendaciones">
+          @for (_ of skeletonItems; track $index) {
+            <div class="book-card book-card--skeleton" aria-hidden="true">
+              <div class="book-card__cover skeleton-box"></div>
+              <div class="book-card__info">
+                <div class="skeleton-line skeleton-line--title"></div>
+                <div class="skeleton-line skeleton-line--author"></div>
+              </div>
+            </div>
+          }
+        </div>
+      } @else if (error()) {
+        <!-- Error state -->
+        <div class="empty-state" role="alert" data-testid="error-state">
+          <span class="material-symbols-outlined empty-icon" aria-hidden="true">error_outline</span>
+          <p class="empty-message">
+            No se pudieron cargar las recomendaciones. Inténtalo de nuevo.
+          </p>
+          <button type="button" class="btn btn-primary" (click)="load()">
+            <span class="material-symbols-outlined" aria-hidden="true">refresh</span>
+            Reintentar
+          </button>
+        </div>
+      } @else if (items().length === 0) {
+        <!-- Empty state -->
+        <div class="empty-state" data-testid="empty-state">
+          <span class="material-symbols-outlined empty-icon" aria-hidden="true">auto_stories</span>
+          <p class="empty-message">Aún no tenemos suficiente historial para recomendarte libros.</p>
+          <p class="empty-hint">Continúa explorando el catálogo y vuelve pronto.</p>
+        </div>
+      } @else {
+        <!-- Recommendations grid -->
+        <div class="recommendations-grid" role="list">
+          @for (item of items(); track item.bookId) {
+            <a
+              class="book-card"
+              [routerLink]="['/books', item.bookId]"
+              role="listitem"
+              [attr.aria-label]="item.title + ' de ' + item.author"
+            >
+              <div class="book-card__cover">
+                @if (item.coverUrl) {
+                  <img
+                    [src]="item.coverUrl"
+                    [alt]="'Portada de ' + item.title"
+                    class="book-card__img"
+                    loading="lazy"
+                  />
+                } @else {
+                  <div class="book-card__cover-placeholder" aria-hidden="true">
+                    <span class="material-symbols-outlined">book</span>
+                  </div>
+                }
+                <div
+                  class="book-card__similarity"
+                  [attr.aria-label]="'Similitud ' + similarityPercent(item.similarity) + '%'"
+                >
+                  {{ similarityPercent(item.similarity) }}%
+                </div>
+              </div>
+              <div class="book-card__info">
+                <p class="book-card__title">{{ item.title }}</p>
+                <p class="book-card__author">{{ item.author }}</p>
+                <p class="book-card__category">{{ item.dominantCategory }}</p>
+              </div>
+            </a>
+          }
+        </div>
+      }
+    </div>
+  `,
+  styles: `
+    :host {
+      display: block;
+      height: 100%;
+    }
+
+    .recommendations-page {
+      padding: 1.5rem;
+      max-width: 1400px;
+      margin: 0 auto;
+    }
+
+    .recommendations-header {
+      margin-bottom: 2rem;
+    }
+
+    .recommendations-title {
+      font-size: 1.75rem;
+      font-weight: 700;
+      margin: 0 0 0.5rem;
+
+      [data-theme='dark'] & {
+        color: rgb(241 245 249);
+      }
+
+      [data-theme='light'] & {
+        color: rgb(15 23 42);
+      }
+    }
+
+    .recommendations-label {
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+      font-size: 0.9375rem;
+      margin: 0;
+
+      [data-theme='dark'] & {
+        color: rgb(148 163 184);
+      }
+
+      [data-theme='light'] & {
+        color: rgb(100 116 139);
+      }
+    }
+
+    .label-icon {
+      font-size: 1.125rem;
+      width: 1.125rem;
+      height: 1.125rem;
+    }
+
+    /* Grid */
+    .recommendations-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 1.5rem;
+    }
+
+    /* Book card */
+    .book-card {
+      display: flex;
+      flex-direction: column;
+      border-radius: 0.75rem;
+      overflow: hidden;
+      text-decoration: none;
+      transition:
+        transform 150ms ease,
+        box-shadow 150ms ease;
+      cursor: pointer;
+
+      [data-theme='dark'] & {
+        background-color: rgb(30 41 59);
+        border: 1px solid rgb(51 65 85);
+      }
+
+      [data-theme='light'] & {
+        background-color: rgb(255 255 255);
+        border: 1px solid rgb(226 232 240);
+        box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.07);
+      }
+
+      &:hover {
+        transform: translateY(-2px);
+
+        [data-theme='dark'] & {
+          box-shadow: 0 8px 16px -4px rgb(0 0 0 / 0.4);
+        }
+
+        [data-theme='light'] & {
+          box-shadow: 0 8px 16px -4px rgb(0 0 0 / 0.12);
+        }
+      }
+
+      &:focus-visible {
+        outline: 2px solid #17a1cf;
+        outline-offset: 2px;
+      }
+    }
+
+    .book-card__cover {
+      position: relative;
+      aspect-ratio: 2/3;
+      background-color: rgb(226 232 240);
+      overflow: hidden;
+
+      [data-theme='dark'] & {
+        background-color: rgb(51 65 85);
+      }
+    }
+
+    .book-card__img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    .book-card__cover-placeholder {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      height: 100%;
+
+      .material-symbols-outlined {
+        font-size: 3rem;
+
+        [data-theme='dark'] & {
+          color: rgb(100 116 139);
+        }
+
+        [data-theme='light'] & {
+          color: rgb(148 163 184);
+        }
+      }
+    }
+
+    .book-card__similarity {
+      position: absolute;
+      bottom: 0.5rem;
+      right: 0.5rem;
+      background-color: #17a1cf;
+      color: white;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.375rem;
+    }
+
+    .book-card__info {
+      padding: 0.75rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .book-card__title {
+      font-size: 0.875rem;
+      font-weight: 600;
+      margin: 0;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+
+      [data-theme='dark'] & {
+        color: rgb(241 245 249);
+      }
+
+      [data-theme='light'] & {
+        color: rgb(15 23 42);
+      }
+    }
+
+    .book-card__author {
+      font-size: 0.8125rem;
+      margin: 0;
+
+      [data-theme='dark'] & {
+        color: rgb(148 163 184);
+      }
+
+      [data-theme='light'] & {
+        color: rgb(100 116 139);
+      }
+    }
+
+    .book-card__category {
+      font-size: 0.75rem;
+      margin: 0;
+
+      [data-theme='dark'] & {
+        color: rgb(100 116 139);
+      }
+
+      [data-theme='light'] & {
+        color: rgb(148 163 184);
+      }
+    }
+
+    /* Skeleton */
+    .book-card--skeleton {
+      pointer-events: none;
+    }
+
+    .skeleton-box {
+      background: linear-gradient(
+        90deg,
+        rgb(226 232 240) 25%,
+        rgb(241 245 249) 50%,
+        rgb(226 232 240) 75%
+      );
+      background-size: 200% 100%;
+      animation: shimmer 1.5s infinite;
+
+      [data-theme='dark'] & {
+        background: linear-gradient(
+          90deg,
+          rgb(51 65 85) 25%,
+          rgb(71 85 105) 50%,
+          rgb(51 65 85) 75%
+        );
+        background-size: 200% 100%;
+      }
+    }
+
+    .skeleton-line {
+      border-radius: 0.25rem;
+      animation: shimmer 1.5s infinite;
+
+      [data-theme='dark'] & {
+        background: linear-gradient(
+          90deg,
+          rgb(51 65 85) 25%,
+          rgb(71 85 105) 50%,
+          rgb(51 65 85) 75%
+        );
+        background-size: 200% 100%;
+      }
+
+      [data-theme='light'] & {
+        background: linear-gradient(
+          90deg,
+          rgb(226 232 240) 25%,
+          rgb(241 245 249) 50%,
+          rgb(226 232 240) 75%
+        );
+        background-size: 200% 100%;
+      }
+    }
+
+    .skeleton-line--title {
+      height: 0.875rem;
+      width: 90%;
+      margin-bottom: 0.375rem;
+    }
+
+    .skeleton-line--author {
+      height: 0.75rem;
+      width: 60%;
+    }
+
+    @keyframes shimmer {
+      0% {
+        background-position: -200% 0;
+      }
+      100% {
+        background-position: 200% 0;
+      }
+    }
+
+    /* Empty / error state */
+    .empty-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 1rem;
+      padding: 4rem 1.5rem;
+      text-align: center;
+    }
+
+    .empty-icon {
+      font-size: 3.5rem;
+
+      [data-theme='dark'] & {
+        color: rgb(100 116 139);
+      }
+
+      [data-theme='light'] & {
+        color: rgb(148 163 184);
+      }
+    }
+
+    .empty-message {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 500;
+      max-width: 400px;
+
+      [data-theme='dark'] & {
+        color: rgb(203 213 225);
+      }
+
+      [data-theme='light'] & {
+        color: rgb(51 65 85);
+      }
+    }
+
+    .empty-hint {
+      margin: 0;
+      font-size: 0.875rem;
+      max-width: 400px;
+
+      [data-theme='dark'] & {
+        color: rgb(100 116 139);
+      }
+
+      [data-theme='light'] & {
+        color: rgb(148 163 184);
+      }
+    }
+
+    /* Button */
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      padding: 0.5rem 1rem;
+      font-size: 0.875rem;
+      font-weight: 500;
+      border-radius: 0.5rem;
+      border: none;
+      cursor: pointer;
+      transition: background-color 150ms ease;
+
+      .material-symbols-outlined {
+        font-size: 1.125rem;
+      }
+    }
+
+    .btn-primary {
+      background-color: #17a1cf;
+      color: white;
+
+      &:hover {
+        background-color: #1389b3;
+      }
+
+      &:focus-visible {
+        outline: 2px solid #17a1cf;
+        outline-offset: 2px;
+      }
+    }
+
+    /* Responsive */
+    @media (max-width: 768px) {
+      .recommendations-page {
+        padding: 1rem;
+      }
+
+      .recommendations-grid {
+        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+        gap: 1rem;
+      }
+    }
+  `,
+})
+export class RecommendationsPageComponent implements OnInit {
+  private readonly recommendationsService = inject(RecommendationsService);
+
+  readonly loading = signal(true);
+  readonly error = signal(false);
+  readonly items = signal<RecommendationItem[]>([]);
+  readonly label = signal('');
+
+  /** Placeholder array for skeleton loading cards */
+  readonly skeletonItems = Array.from({ length: 8 });
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.loading.set(true);
+    this.error.set(false);
+
+    this.recommendationsService
+      .getRecommendations()
+      .pipe(catchError(() => of(null)))
+      .subscribe((response) => {
+        if (response === null) {
+          this.error.set(true);
+        } else {
+          this.items.set(response.items);
+          this.label.set(response.label);
+        }
+        this.loading.set(false);
+      });
+  }
+
+  /** Convert a 0–1 similarity score to a whole-number percentage */
+  similarityPercent(similarity: number): number {
+    return Math.round(similarity * 100);
+  }
+}

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -29,6 +29,8 @@ tags:
     description: "Operaciones de consulta de categorías (endpoint: /book-categories)"
   - name: Favorites
     description: "Operaciones de gestión de favoritos del usuario autenticado"
+  - name: Recommendations
+    description: "Recomendaciones personalizadas de libros basadas en el historial de lectura del usuario"
 
 paths:
   # ============================================
@@ -1150,6 +1152,95 @@ paths:
                 error:
                   message: "Book with id \"550e8400-e29b-41d4-a716-446655440000\" not found"
 
+  # ============================================
+  # HU-040: Book Recommendations Endpoints
+  # ============================================
+
+  /books/recommendations:
+    get:
+      tags:
+        - Recommendations
+      summary: Obtener recomendaciones personalizadas de libros
+      description: |
+        Devuelve una lista de libros recomendados para el usuario autenticado, basada en su historial de descargas.
+
+        ## Algoritmo
+
+        1. Se obtienen los últimos libros descargados por el usuario.
+        2. Se genera un embedding promedio de las categorías dominantes de esos libros.
+        3. Se buscan libros similares en el catálogo usando similitud vectorial (≥70%).
+        4. Se excluyen los libros ya descargados por el usuario.
+        5. Se devuelven hasta 10 recomendaciones ordenadas por similitud descendente.
+
+        ## Sin historial
+
+        Si el usuario no tiene descargas registradas, se devuelve una lista vacía con `label: ""`.
+
+        ## Autenticación
+
+        Requiere un JWT válido en la cookie `access_token`. Si el token está ausente o es inválido,
+        se retorna `401 Unauthorized`.
+      operationId: getBookRecommendations
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          description: Recomendaciones obtenidas exitosamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookRecommendationsResponse'
+              examples:
+                with_recommendations:
+                  summary: Usuario con historial — recomendaciones disponibles
+                  value:
+                    success: true
+                    data:
+                      items:
+                        - bookId: "550e8400-e29b-41d4-a716-446655440000"
+                          title: "Clean Code"
+                          author: "Robert C. Martin"
+                          coverUrl: "https://example.com/covers/clean-code.jpg"
+                          similarity: 0.87
+                          dominantCategory: "Programming"
+                        - bookId: "550e8400-e29b-41d4-a716-446655440001"
+                          title: "The Pragmatic Programmer"
+                          author: "David Thomas"
+                          coverUrl: null
+                          similarity: 0.74
+                          dominantCategory: "Programming"
+                      label: "Porque te interesa Programación"
+                    error: null
+                no_history:
+                  summary: Usuario sin historial — lista vacía
+                  value:
+                    success: true
+                    data:
+                      items: []
+                      label: ""
+                    error: null
+        '401':
+          description: No autenticado. El token JWT está ausente o es inválido.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                missing_token:
+                  summary: Token ausente
+                  value:
+                    success: false
+                    data: null
+                    error:
+                      message: "Unauthorized"
+                invalid_token:
+                  summary: Token inválido o expirado
+                  value:
+                    success: false
+                    data: null
+                    error:
+                      message: "Unauthorized"
+
   /book-types:
     get:
       tags:
@@ -1995,6 +2086,75 @@ components:
           properties:
             data:
               $ref: '#/components/schemas/FavoriteToggleData'
+
+    # ============================================
+    # HU-040: Book Recommendations Schemas
+    # ============================================
+
+    BookRecommendationItem:
+      type: object
+      required:
+        - bookId
+        - title
+        - author
+        - similarity
+        - dominantCategory
+      properties:
+        bookId:
+          type: string
+          format: uuid
+          description: Identificador único del libro recomendado (UUID v4)
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        title:
+          type: string
+          description: Título del libro
+          example: "Clean Code"
+        author:
+          type: string
+          description: Autor principal del libro
+          example: "Robert C. Martin"
+        coverUrl:
+          type: string
+          nullable: true
+          description: URL de la portada del libro, o `null` si no tiene portada asignada
+          example: "https://example.com/covers/clean-code.jpg"
+        similarity:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+          description: Puntuación de similitud vectorial con el perfil de lectura del usuario (0.0 - 1.0)
+          example: 0.87
+        dominantCategory:
+          type: string
+          description: Categoría dominante del libro, usada para generar la etiqueta de recomendación
+          example: "Programming"
+
+    BookRecommendationsData:
+      type: object
+      required:
+        - items
+        - label
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/BookRecommendationItem'
+          description: Lista de libros recomendados (máximo 10). Vacía si el usuario no tiene historial.
+        label:
+          type: string
+          description: |
+            Etiqueta descriptiva de la recomendación, ej. `"Porque te interesa Programación"`.
+            Cadena vacía si no hay recomendaciones disponibles.
+          example: "Porque te interesa Programación"
+
+    BookRecommendationsResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessResponse'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/BookRecommendationsData'
 
   securitySchemes:
     cookieAuth:


### PR DESCRIPTION
## HU-040 — Recomendaciones personalizadas de libros

Implementa content-based filtering con centroide de embeddings para recomendar libros basados en el historial del usuario.

### Cambios incluidos

**Dominio:**
- `RecommendationItem` — Value Object inmutable con validación de similarity
- `computeCentroid` — promedio L2 de embeddings con validación de dimensiones consistentes
- `getDominantCategory` — categoría más frecuente del historial del usuario

**Application:**
- `GetRecommendationsUseCase` — calcula centroide de embeddings de favoritos + descargas, busca los 20 libros más similares (umbral 55%), excluye seeds, obtiene categoría dominante directamente desde los seeds

**Infraestructura:**
- `DrizzleDownloadRepository.findAllByUser` — últimos 100 downloads del usuario
- `PostgresBookRepository.findEmbeddingsByIds` — embeddings no-nulos por IDs
- `PostgresBookRepository.findCategoriesByIds` — categorías de seeds para el label
- Migración: índice en `user_book_downloads.user_id`
- `RecommendationsController` + ruta `GET /api/books/recommendations` (registrada antes de `/:id`)

**Frontend:**
- `RecommendationsService` + `RecommendationsPageComponent` (estados: loading, vacío, grid)
- Ruta `/recommendations` con auth guard inline
- Enlace "Para ti" en el header (solo para autenticados)

**Docs:**
- OpenAPI: path, schemas y ejemplos para el nuevo endpoint
- Notion: Developer Documentation + Product Overview actualizados

### Tests
- 81 archivos, 1676 tests unitarios ✅
- Tests de integración para los nuevos métodos de repositorio ✅
- 5 tests E2E para el endpoint HTTP ✅
- TDD aplicado en todas las tareas

### Issues
Closes #447
Closes #448
Closes #449
Closes #450
Closes #451
Closes #452
Closes #453
Closes #454
