### PR TITLE
feat(HU-043): navegacion responsive mobile/tablet con bottom nav bar

### DIFF
--- a/apps/web-client/src/app/catalog/pages/book-list/book-list-page.component.spec.ts
+++ b/apps/web-client/src/app/catalog/pages/book-list/book-list-page.component.spec.ts
@@ -7,6 +7,7 @@ import { of, Subject } from 'rxjs';
 import { BookListPageComponent } from './book-list-page.component.js';
 import { BookSearchStore } from '../../../core/services/book-search.store.js';
 import { DialogService } from '../../../core/services/dialog.service.js';
+import { LayoutService } from '../../../layout/layout.service.js';
 import {
   Book,
   PaginationInfo,
@@ -107,12 +108,17 @@ describe('BookListPageComponent', () => {
       } as unknown as DialogRef<unknown>),
     };
 
+    const mockLayoutService = {
+      isMobile: signal(false),
+    };
+
     await TestBed.configureTestingModule({
       imports: [BookListPageComponent],
       providers: [
         provideZonelessChangeDetection(),
         { provide: BookSearchStore, useValue: mockStore },
         { provide: DialogService, useValue: mockDialogService },
+        { provide: LayoutService, useValue: mockLayoutService },
       ],
     }).compileComponents();
 
@@ -413,7 +419,7 @@ describe('BookListPageComponent', () => {
   });
 });
 
-// ─── Mobile layout suite (separate TestBed with BreakpointObserver mocked as mobile) ───
+// ─── Mobile layout suite (separate TestBed with LayoutService mocked as mobile) ───
 describe('BookListPageComponent – Mobile layout', () => {
   let component: BookListPageComponent;
   let fixture: ComponentFixture<BookListPageComponent>;
@@ -478,11 +484,8 @@ describe('BookListPageComponent – Mobile layout', () => {
       } as unknown as DialogRef<unknown>),
     };
 
-    const mockBreakpointObserver = {
-      observe: vi.fn().mockReturnValue(
-        // Emit mobile=true immediately
-        of({ matches: true, breakpoints: {} } as BreakpointState)
-      ),
+    const mockLayoutService = {
+      isMobile: signal(true),
     };
 
     await TestBed.configureTestingModule({
@@ -490,7 +493,7 @@ describe('BookListPageComponent – Mobile layout', () => {
       providers: [
         { provide: BookSearchStore, useValue: mockStore },
         { provide: DialogService, useValue: mockDialogService },
-        { provide: BreakpointObserver, useValue: mockBreakpointObserver },
+        { provide: LayoutService, useValue: mockLayoutService },
       ],
     }).compileComponents();
 

--- a/apps/web-client/src/app/catalog/pages/book-list/book-list-page.component.spec.ts
+++ b/apps/web-client/src/app/catalog/pages/book-list/book-list-page.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { signal, provideZonelessChangeDetection } from '@angular/core';
-import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
+import { BreakpointState } from '@angular/cdk/layout';
 import { DialogRef } from '@angular/cdk/dialog';
 import { of, Subject } from 'rxjs';
 

--- a/apps/web-client/src/app/catalog/pages/book-list/book-list-page.component.ts
+++ b/apps/web-client/src/app/catalog/pages/book-list/book-list-page.component.ts
@@ -6,9 +6,6 @@ import {
   OnInit,
   ChangeDetectionStrategy,
 } from '@angular/core';
-import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { map } from 'rxjs';
 
 import {
   Book,
@@ -26,6 +23,7 @@ import { SendToKindleDialogComponent } from '../../components/dialogs/index.js';
 import { BookSearchStore } from '../../../core/services/book-search.store.js';
 import { DialogService } from '../../../core/services/dialog.service.js';
 import { AuthService } from '../../../auth/auth.service.js';
+import { LayoutService } from '../../../layout/layout.service.js';
 
 /**
  * BookListPageComponent - Main page for book catalog search and listing
@@ -446,7 +444,7 @@ export class BookListPageComponent implements OnInit {
   readonly store = inject(BookSearchStore);
   private readonly dialogService = inject(DialogService);
   private readonly authService = inject(AuthService);
-  private readonly breakpointObserver = inject(BreakpointObserver);
+  private readonly layoutService = inject(LayoutService);
 
   /** True when a user is logged in */
   readonly isAuthenticated = computed(() => this.authService.currentUser() !== null);
@@ -454,13 +452,8 @@ export class BookListPageComponent implements OnInit {
   // Mobile state
   readonly isMobileDrawerOpen = signal(false);
 
-  // Responsive breakpoint
-  readonly isMobile = toSignal(
-    this.breakpointObserver
-      .observe([Breakpoints.XSmall, Breakpoints.Small])
-      .pipe(map((result) => result.matches)),
-    { initialValue: false }
-  );
+  // Responsive breakpoint (delegated to LayoutService)
+  readonly isMobile = this.layoutService.isMobile;
 
   // Count active filters for badge
   readonly activeFilterCount = computed(() => {

--- a/apps/web-client/src/app/catalog/pages/book-list/book-list-page.component.ts
+++ b/apps/web-client/src/app/catalog/pages/book-list/book-list-page.component.ts
@@ -203,7 +203,7 @@ import { LayoutService } from '../../../layout/layout.service.js';
     .backdrop {
       position: fixed;
       inset: 0;
-      z-index: 40;
+      z-index: 49;
       backdrop-filter: blur(2px);
       animation: fadeIn 0.3s ease;
       background-color: rgba(15, 23, 42, 0.7); /* slate-900 */

--- a/apps/web-client/src/app/layout/bottom-nav/bottom-nav.component.spec.ts
+++ b/apps/web-client/src/app/layout/bottom-nav/bottom-nav.component.spec.ts
@@ -1,0 +1,137 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { signal, provideZonelessChangeDetection } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { Dialog } from '@angular/cdk/dialog';
+import { of } from 'rxjs';
+
+import { BottomNavComponent } from './bottom-nav.component.js';
+import { AuthService } from '../../auth/auth.service.js';
+
+describe('BottomNavComponent', () => {
+  let component: BottomNavComponent;
+  let fixture: ComponentFixture<BottomNavComponent>;
+  let mockAuthService: {
+    currentUser: ReturnType<typeof signal<{ email: string } | null>>;
+    logout: ReturnType<typeof vi.fn>;
+  };
+  let mockDialog: { open: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    const currentUserSignal = signal<{ email: string } | null>(null);
+
+    mockAuthService = {
+      currentUser: currentUserSignal,
+      logout: vi.fn(),
+    };
+
+    mockDialog = {
+      open: vi.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [BottomNavComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        { provide: AuthService, useValue: mockAuthService },
+        { provide: Dialog, useValue: mockDialog },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BottomNavComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Unauthenticated state (currentUser = null)', () => {
+    it('should show the "Entrar" button when unauthenticated', () => {
+      const btn = fixture.nativeElement.querySelector('.bottom-nav__item');
+      expect(btn).toBeTruthy();
+      expect(btn.textContent).toContain('Entrar');
+    });
+
+    it('should NOT show catalog or recommendations links when unauthenticated', () => {
+      const links = fixture.nativeElement.querySelectorAll('a.bottom-nav__item');
+      expect(links.length).toBe(0);
+    });
+
+    it('should NOT show logout button when unauthenticated', () => {
+      const buttons = fixture.nativeElement.querySelectorAll('button.bottom-nav__item');
+      const logoutBtn = Array.from(buttons).find((btn: unknown) =>
+        (btn as HTMLElement).textContent?.includes('Salir')
+      );
+      expect(logoutBtn).toBeFalsy();
+    });
+  });
+
+  describe('Authenticated state (currentUser has email)', () => {
+    beforeEach(() => {
+      mockAuthService.currentUser.set({ email: 'user@example.com' });
+      fixture.detectChanges();
+    });
+
+    it('should show the Catálogo link when authenticated', () => {
+      const links = fixture.nativeElement.querySelectorAll('a.bottom-nav__item');
+      const catalogLink = Array.from(links).find((link: unknown) =>
+        (link as HTMLElement).textContent?.includes('Catálogo')
+      );
+      expect(catalogLink).toBeTruthy();
+    });
+
+    it('should show the Para ti link when authenticated', () => {
+      const links = fixture.nativeElement.querySelectorAll('a.bottom-nav__item');
+      const paraLink = Array.from(links).find((link: unknown) =>
+        (link as HTMLElement).textContent?.includes('Para ti')
+      );
+      expect(paraLink).toBeTruthy();
+    });
+
+    it('should show the logout button when authenticated', () => {
+      const buttons = fixture.nativeElement.querySelectorAll('button.bottom-nav__item');
+      const logoutBtn = Array.from(buttons).find((btn: unknown) =>
+        (btn as HTMLElement).textContent?.includes('Salir')
+      );
+      expect(logoutBtn).toBeTruthy();
+    });
+
+    it('should NOT show the "Entrar" button when authenticated', () => {
+      const buttons = fixture.nativeElement.querySelectorAll('button.bottom-nav__item');
+      const loginBtn = Array.from(buttons).find((btn: unknown) =>
+        (btn as HTMLElement).textContent?.includes('Entrar')
+      );
+      expect(loginBtn).toBeFalsy();
+    });
+  });
+
+  describe('openLoginModal()', () => {
+    it('should call Dialog.open when "Entrar" button is clicked', () => {
+      const btn = fixture.nativeElement.querySelector('button.bottom-nav__item');
+      btn.click();
+      expect(mockDialog.open).toHaveBeenCalled();
+    });
+  });
+
+  describe('logout()', () => {
+    beforeEach(() => {
+      mockAuthService.currentUser.set({ email: 'user@example.com' });
+      fixture.detectChanges();
+    });
+
+    it('should call authService.logout() when logout button is clicked', () => {
+      mockAuthService.logout.mockReturnValue(of(undefined));
+
+      const buttons = fixture.nativeElement.querySelectorAll('button.bottom-nav__item');
+      const logoutBtn = Array.from(buttons).find((btn: unknown) =>
+        (btn as HTMLElement).textContent?.includes('Salir')
+      ) as HTMLElement;
+
+      logoutBtn.click();
+
+      expect(mockAuthService.logout).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web-client/src/app/layout/bottom-nav/bottom-nav.component.ts
+++ b/apps/web-client/src/app/layout/bottom-nav/bottom-nav.component.ts
@@ -1,6 +1,7 @@
-import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, DestroyRef } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { Dialog } from '@angular/cdk/dialog';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { AuthService } from '../../auth/auth.service.js';
 import { LoginModalComponent } from '../../auth/login-modal/login-modal.component.js';
@@ -115,6 +116,7 @@ import { LoginModalComponent } from '../../auth/login-modal/login-modal.componen
 export class BottomNavComponent {
   readonly authService = inject(AuthService);
   private readonly dialog = inject(Dialog);
+  private readonly destroyRef = inject(DestroyRef);
 
   openLoginModal(): void {
     this.dialog.open(LoginModalComponent, {
@@ -125,6 +127,6 @@ export class BottomNavComponent {
   }
 
   logout(): void {
-    this.authService.logout().subscribe();
+    this.authService.logout().pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
   }
 }

--- a/apps/web-client/src/app/layout/bottom-nav/bottom-nav.component.ts
+++ b/apps/web-client/src/app/layout/bottom-nav/bottom-nav.component.ts
@@ -1,0 +1,130 @@
+import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { RouterLink, RouterLinkActive } from '@angular/router';
+import { Dialog } from '@angular/cdk/dialog';
+
+import { AuthService } from '../../auth/auth.service.js';
+import { LoginModalComponent } from '../../auth/login-modal/login-modal.component.js';
+
+/**
+ * BottomNavComponent - Mobile bottom navigation bar
+ *
+ * Features:
+ * - Fixed positioning at the bottom of the viewport
+ * - Auth-aware: shows nav links when authenticated, login button when not
+ * - Glassmorphism background with blur effect
+ */
+@Component({
+  selector: 'app-bottom-nav',
+  standalone: true,
+  imports: [RouterLink, RouterLinkActive],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <nav class="bottom-nav" role="navigation" aria-label="Navegación móvil">
+      @if (authService.currentUser() !== null) {
+        <a
+          class="bottom-nav__item"
+          routerLink="/books"
+          routerLinkActive="bottom-nav__item--active"
+          aria-label="Catálogo de libros"
+        >
+          <span class="material-symbols-outlined bottom-nav__icon" aria-hidden="true"
+            >menu_book</span
+          >
+          Catálogo
+        </a>
+        <a
+          class="bottom-nav__item"
+          routerLink="/recommendations"
+          routerLinkActive="bottom-nav__item--active"
+          aria-label="Para ti — recomendaciones personalizadas"
+        >
+          <span class="material-symbols-outlined bottom-nav__icon" aria-hidden="true"
+            >recommend</span
+          >
+          Para ti
+        </a>
+        <button class="bottom-nav__item" (click)="logout()" aria-label="Cerrar sesión">
+          <span class="material-symbols-outlined bottom-nav__icon" aria-hidden="true">logout</span>
+          Salir
+        </button>
+      } @else {
+        <button class="bottom-nav__item" (click)="openLoginModal()" aria-label="Iniciar sesión">
+          <span class="material-symbols-outlined bottom-nav__icon" aria-hidden="true"
+            >account_circle</span
+          >
+          Entrar
+        </button>
+      }
+    </nav>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+
+      .bottom-nav {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: var(--bottom-nav-height, 56px);
+        z-index: 40;
+        display: flex;
+        align-items: center;
+        justify-content: space-around;
+        background-color: rgba(17, 29, 33, 0.95);
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
+        border-top: 1px solid var(--color-border);
+      }
+
+      .bottom-nav__item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 2px;
+        padding: 4px 12px;
+        color: rgb(148 163 184);
+        text-decoration: none;
+        font-size: 0.625rem;
+        font-weight: 500;
+        background: none;
+        border: none;
+        cursor: pointer;
+        border-radius: 0.5rem;
+        transition: color 150ms ease;
+
+        &:hover {
+          color: var(--color-accent);
+        }
+      }
+
+      .bottom-nav__item--active {
+        color: var(--color-accent);
+      }
+
+      .bottom-nav__icon {
+        font-size: 22px;
+        width: 22px;
+        height: 22px;
+      }
+    `,
+  ],
+})
+export class BottomNavComponent {
+  readonly authService = inject(AuthService);
+  private readonly dialog = inject(Dialog);
+
+  openLoginModal(): void {
+    this.dialog.open(LoginModalComponent, {
+      panelClass: 'dialog-panel',
+      backdropClass: 'dialog-backdrop',
+      hasBackdrop: true,
+    });
+  }
+
+  logout(): void {
+    this.authService.logout().subscribe();
+  }
+}

--- a/apps/web-client/src/app/layout/bottom-nav/index.ts
+++ b/apps/web-client/src/app/layout/bottom-nav/index.ts
@@ -1,0 +1,1 @@
+export * from './bottom-nav.component.js';

--- a/apps/web-client/src/app/layout/header/header.component.spec.ts
+++ b/apps/web-client/src/app/layout/header/header.component.spec.ts
@@ -6,6 +6,7 @@ import { of } from 'rxjs';
 
 import { HeaderComponent } from './header.component.js';
 import { AuthService } from '../../auth/auth.service.js';
+import { LayoutService } from '../layout.service.js';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
@@ -15,6 +16,7 @@ describe('HeaderComponent', () => {
     logout: ReturnType<typeof vi.fn>;
   };
   let mockDialog: { open: ReturnType<typeof vi.fn> };
+  let mockLayoutService: { isMobile: ReturnType<typeof signal<boolean>> };
 
   beforeEach(async () => {
     const currentUserSignal = signal<{ email: string } | null>(null);
@@ -28,12 +30,17 @@ describe('HeaderComponent', () => {
       open: vi.fn(),
     };
 
+    mockLayoutService = {
+      isMobile: signal(false),
+    };
+
     await TestBed.configureTestingModule({
       imports: [HeaderComponent],
       providers: [
         provideZonelessChangeDetection(),
         { provide: AuthService, useValue: mockAuthService },
         { provide: Dialog, useValue: mockDialog },
+        { provide: LayoutService, useValue: mockLayoutService },
       ],
     }).compileComponents();
 
@@ -198,6 +205,51 @@ describe('HeaderComponent', () => {
     it('should include skip link target or appropriate structure', () => {
       const brand = fixture.nativeElement.querySelector('.header__brand');
       expect(brand).toBeTruthy();
+    });
+  });
+
+  describe('Mobile state (isMobile = true)', () => {
+    beforeEach(() => {
+      mockLayoutService.isMobile.set(true);
+      fixture.detectChanges();
+    });
+
+    it('should hide nav links', () => {
+      mockAuthService.currentUser.set({ email: 'user@example.com' });
+      fixture.detectChanges();
+
+      const nav = fixture.nativeElement.querySelector('.header__nav');
+      expect(nav).toBeFalsy();
+    });
+
+    it('should hide actions area', () => {
+      const actions = fixture.nativeElement.querySelector('.header__actions');
+      expect(actions).toBeFalsy();
+    });
+
+    it('should still render brand', () => {
+      const brand = fixture.nativeElement.querySelector('.header__brand');
+      expect(brand).toBeTruthy();
+    });
+  });
+
+  describe('Desktop state (isMobile = false)', () => {
+    beforeEach(() => {
+      mockLayoutService.isMobile.set(false);
+      fixture.detectChanges();
+    });
+
+    it('should show nav links when authenticated', () => {
+      mockAuthService.currentUser.set({ email: 'user@example.com' });
+      fixture.detectChanges();
+
+      const nav = fixture.nativeElement.querySelector('.header__nav');
+      expect(nav).toBeTruthy();
+    });
+
+    it('should show actions area', () => {
+      const actions = fixture.nativeElement.querySelector('.header__actions');
+      expect(actions).toBeTruthy();
     });
   });
 });

--- a/apps/web-client/src/app/layout/header/header.component.spec.ts
+++ b/apps/web-client/src/app/layout/header/header.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { signal, provideZonelessChangeDetection } from '@angular/core';
+import { provideRouter } from '@angular/router';
 import { Dialog } from '@angular/cdk/dialog';
 import { of } from 'rxjs';
 
@@ -37,6 +38,7 @@ describe('HeaderComponent', () => {
       imports: [HeaderComponent],
       providers: [
         provideZonelessChangeDetection(),
+        provideRouter([]),
         { provide: AuthService, useValue: mockAuthService },
         { provide: Dialog, useValue: mockDialog },
         { provide: LayoutService, useValue: mockLayoutService },

--- a/apps/web-client/src/app/layout/header/header.component.spec.ts
+++ b/apps/web-client/src/app/layout/header/header.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { signal, provideZonelessChangeDetection } from '@angular/core';
-import { provideRouter } from '@angular/router';
 import { Dialog } from '@angular/cdk/dialog';
 import { of } from 'rxjs';
 

--- a/apps/web-client/src/app/layout/header/header.component.ts
+++ b/apps/web-client/src/app/layout/header/header.component.ts
@@ -4,6 +4,7 @@ import { Dialog } from '@angular/cdk/dialog';
 
 import { AuthService } from '../../auth/auth.service.js';
 import { LoginModalComponent } from '../../auth/login-modal/login-modal.component.js';
+import { LayoutService } from '../layout.service.js';
 
 /**
  * HeaderComponent - Application header with logo, actions and auth state
@@ -31,7 +32,7 @@ import { LoginModalComponent } from '../../auth/login-modal/login-modal.componen
         </div>
       </a>
 
-      @if (authService.currentUser() !== null) {
+      @if (!isMobile() && authService.currentUser() !== null) {
         <nav class="header__nav" aria-label="Navegación principal">
           <a
             class="header__nav-link"
@@ -58,6 +59,7 @@ import { LoginModalComponent } from '../../auth/login-modal/login-modal.componen
         </nav>
       }
 
+      @if (!isMobile()) {
       <div class="header__actions">
         @if (authService.currentUser() === null) {
           <!-- Unauthenticated: show login icon -->
@@ -96,6 +98,7 @@ import { LoginModalComponent } from '../../auth/login-modal/login-modal.componen
           </div>
         }
       </div>
+      }
     </header>
   `,
   styles: [
@@ -334,7 +337,9 @@ import { LoginModalComponent } from '../../auth/login-modal/login-modal.componen
 export class HeaderComponent {
   readonly authService = inject(AuthService);
   private readonly dialog = inject(Dialog);
+  private readonly layoutService = inject(LayoutService);
 
+  readonly isMobile = this.layoutService.isMobile;
   readonly isDropdownOpen = signal(false);
 
   openLoginModal(): void {

--- a/apps/web-client/src/app/layout/header/header.component.ts
+++ b/apps/web-client/src/app/layout/header/header.component.ts
@@ -60,44 +60,44 @@ import { LayoutService } from '../layout.service.js';
       }
 
       @if (!isMobile()) {
-      <div class="header__actions">
-        @if (authService.currentUser() === null) {
-          <!-- Unauthenticated: show login icon -->
-          <div
-            class="header__avatar"
-            role="button"
-            tabindex="0"
-            aria-label="Iniciar sesión"
-            (click)="openLoginModal()"
-            (keydown.enter)="openLoginModal()"
-          >
-            <span class="material-symbols-outlined">account_circle</span>
-          </div>
-        } @else {
-          <!-- Authenticated: show user menu -->
-          <div
-            class="header__user"
-            (click)="toggleDropdown()"
-            (keydown.enter)="toggleDropdown()"
-            role="button"
-            tabindex="0"
-            aria-label="Menú de usuario"
-            aria-haspopup="true"
-            [attr.aria-expanded]="isDropdownOpen()"
-          >
-            <span class="header__email">{{ authService.currentUser()!.email }}</span>
-            <span class="material-symbols-outlined header__user-icon">account_circle</span>
-            @if (isDropdownOpen()) {
-              <div class="header__dropdown" role="menu">
-                <button class="header__dropdown-item" role="menuitem" (click)="logout($event)">
-                  <span class="material-symbols-outlined">logout</span>
-                  Desconectarse
-                </button>
-              </div>
-            }
-          </div>
-        }
-      </div>
+        <div class="header__actions">
+          @if (authService.currentUser() === null) {
+            <!-- Unauthenticated: show login icon -->
+            <div
+              class="header__avatar"
+              role="button"
+              tabindex="0"
+              aria-label="Iniciar sesión"
+              (click)="openLoginModal()"
+              (keydown.enter)="openLoginModal()"
+            >
+              <span class="material-symbols-outlined">account_circle</span>
+            </div>
+          } @else {
+            <!-- Authenticated: show user menu -->
+            <div
+              class="header__user"
+              (click)="toggleDropdown()"
+              (keydown.enter)="toggleDropdown()"
+              role="button"
+              tabindex="0"
+              aria-label="Menú de usuario"
+              aria-haspopup="true"
+              [attr.aria-expanded]="isDropdownOpen()"
+            >
+              <span class="header__email">{{ authService.currentUser()!.email }}</span>
+              <span class="material-symbols-outlined header__user-icon">account_circle</span>
+              @if (isDropdownOpen()) {
+                <div class="header__dropdown" role="menu">
+                  <button class="header__dropdown-item" role="menuitem" (click)="logout($event)">
+                    <span class="material-symbols-outlined">logout</span>
+                    Desconectarse
+                  </button>
+                </div>
+              }
+            </div>
+          }
+        </div>
       }
     </header>
   `,

--- a/apps/web-client/src/app/layout/index.ts
+++ b/apps/web-client/src/app/layout/index.ts
@@ -8,3 +8,4 @@ export * from './main-layout/index.js';
 export * from './header/index.js';
 export * from './footer/index.js';
 export * from './layout.service.js';
+export * from './bottom-nav/index.js';

--- a/apps/web-client/src/app/layout/index.ts
+++ b/apps/web-client/src/app/layout/index.ts
@@ -7,3 +7,4 @@
 export * from './main-layout/index.js';
 export * from './header/index.js';
 export * from './footer/index.js';
+export * from './layout.service.js';

--- a/apps/web-client/src/app/layout/layout.service.spec.ts
+++ b/apps/web-client/src/app/layout/layout.service.spec.ts
@@ -8,9 +8,9 @@ describe('LayoutService', () => {
   describe('isMobile on desktop', () => {
     beforeEach(() => {
       const mockBreakpointObserver = {
-        observe: vi.fn().mockReturnValue(
-          of({ matches: false, breakpoints: {} } as BreakpointState)
-        ),
+        observe: vi
+          .fn()
+          .mockReturnValue(of({ matches: false, breakpoints: {} } as BreakpointState)),
       };
 
       TestBed.configureTestingModule({
@@ -30,9 +30,7 @@ describe('LayoutService', () => {
   describe('isMobile on mobile/tablet', () => {
     beforeEach(() => {
       const mockBreakpointObserver = {
-        observe: vi.fn().mockReturnValue(
-          of({ matches: true, breakpoints: {} } as BreakpointState)
-        ),
+        observe: vi.fn().mockReturnValue(of({ matches: true, breakpoints: {} } as BreakpointState)),
       };
 
       TestBed.configureTestingModule({

--- a/apps/web-client/src/app/layout/layout.service.spec.ts
+++ b/apps/web-client/src/app/layout/layout.service.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed } from '@angular/core/testing';
+import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
+import { of } from 'rxjs';
+
+import { LayoutService } from './layout.service.js';
+
+describe('LayoutService', () => {
+  describe('isMobile on desktop', () => {
+    beforeEach(() => {
+      const mockBreakpointObserver = {
+        observe: vi.fn().mockReturnValue(
+          of({ matches: false, breakpoints: {} } as BreakpointState)
+        ),
+      };
+
+      TestBed.configureTestingModule({
+        providers: [
+          LayoutService,
+          { provide: BreakpointObserver, useValue: mockBreakpointObserver },
+        ],
+      });
+    });
+
+    it('should return false when breakpoint does not match (desktop)', () => {
+      const service = TestBed.inject(LayoutService);
+      expect(service.isMobile()).toBe(false);
+    });
+  });
+
+  describe('isMobile on mobile/tablet', () => {
+    beforeEach(() => {
+      const mockBreakpointObserver = {
+        observe: vi.fn().mockReturnValue(
+          of({ matches: true, breakpoints: {} } as BreakpointState)
+        ),
+      };
+
+      TestBed.configureTestingModule({
+        providers: [
+          LayoutService,
+          { provide: BreakpointObserver, useValue: mockBreakpointObserver },
+        ],
+      });
+    });
+
+    it('should return true when XSmall or Small breakpoint matches (mobile)', () => {
+      const service = TestBed.inject(LayoutService);
+      expect(service.isMobile()).toBe(true);
+    });
+
+    it('should return true when Small breakpoint matches (tablet)', () => {
+      const service = TestBed.inject(LayoutService);
+      expect(service.isMobile()).toBe(true);
+    });
+  });
+});

--- a/apps/web-client/src/app/layout/layout.service.ts
+++ b/apps/web-client/src/app/layout/layout.service.ts
@@ -1,0 +1,16 @@
+import { Injectable, inject } from '@angular/core';
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class LayoutService {
+  private readonly breakpointObserver = inject(BreakpointObserver);
+
+  readonly isMobile = toSignal(
+    this.breakpointObserver
+      .observe([Breakpoints.XSmall, Breakpoints.Small])
+      .pipe(map((result) => result.matches)),
+    { initialValue: false }
+  );
+}

--- a/apps/web-client/src/app/layout/main-layout/main-layout.component.spec.ts
+++ b/apps/web-client/src/app/layout/main-layout/main-layout.component.spec.ts
@@ -3,15 +3,30 @@ import { provideAnimationsAsync } from '@angular/platform-browser/animations/asy
 import { provideRouter } from '@angular/router';
 import { MainLayoutComponent } from './main-layout.component.js';
 import { provideZonelessChangeDetection } from '@angular/core';
+import { signal } from '@angular/core';
+import { LayoutService } from '../layout.service.js';
+import { AuthService } from '../../auth/auth.service.js';
+import { Dialog } from '@angular/cdk/dialog';
+import { vi } from 'vitest';
 
 describe('MainLayoutComponent', () => {
   let component: MainLayoutComponent;
   let fixture: ComponentFixture<MainLayoutComponent>;
+  let isMobileSignal: ReturnType<typeof signal<boolean>>;
 
   beforeEach(async () => {
+    isMobileSignal = signal(false);
+
     await TestBed.configureTestingModule({
       imports: [MainLayoutComponent],
-      providers: [provideZonelessChangeDetection(), provideAnimationsAsync(), provideRouter([])],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideAnimationsAsync(),
+        provideRouter([]),
+        { provide: LayoutService, useValue: { isMobile: isMobileSignal } },
+        { provide: AuthService, useValue: { currentUser: signal(null), logout: vi.fn() } },
+        { provide: Dialog, useValue: { open: vi.fn() } },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MainLayoutComponent);
@@ -77,7 +92,7 @@ describe('MainLayoutComponent', () => {
   });
 
   describe('Layout Order', () => {
-    it('should have correct order: header → content → footer', () => {
+    it('should have correct order: header → content → footer (desktop)', () => {
       const container = fixture.nativeElement.querySelector('.main-layout');
       const children = Array.from(container.children) as Element[];
 
@@ -85,6 +100,53 @@ describe('MainLayoutComponent', () => {
       expect(children[0].tagName.toLowerCase()).toBe('app-header');
       expect(children[1].tagName.toLowerCase()).toBe('main');
       expect(children[2].tagName.toLowerCase()).toBe('app-footer');
+    });
+
+    it('should show app-bottom-nav in mobile', async () => {
+      isMobileSignal.set(true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const bottomNav = fixture.nativeElement.querySelector('app-bottom-nav');
+      expect(bottomNav).toBeTruthy();
+    });
+  });
+
+  describe('Bottom Nav', () => {
+    it('should render bottom-nav when mobile', async () => {
+      isMobileSignal.set(true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const bottomNav = fixture.nativeElement.querySelector('app-bottom-nav');
+      expect(bottomNav).toBeTruthy();
+    });
+
+    it('should NOT render bottom-nav when desktop', () => {
+      isMobileSignal.set(false);
+      fixture.detectChanges();
+
+      const bottomNav = fixture.nativeElement.querySelector('app-bottom-nav');
+      expect(bottomNav).toBeFalsy();
+    });
+  });
+
+  describe('Mobile padding', () => {
+    it('should add mobile class to content when isMobile is true', async () => {
+      isMobileSignal.set(true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const content = fixture.nativeElement.querySelector('.main-layout__content');
+      expect(content.classList.contains('main-layout__content--mobile')).toBe(true);
+    });
+
+    it('should NOT add mobile class when desktop', () => {
+      isMobileSignal.set(false);
+      fixture.detectChanges();
+
+      const content = fixture.nativeElement.querySelector('.main-layout__content');
+      expect(content.classList.contains('main-layout__content--mobile')).toBe(false);
     });
   });
 });

--- a/apps/web-client/src/app/layout/main-layout/main-layout.component.ts
+++ b/apps/web-client/src/app/layout/main-layout/main-layout.component.ts
@@ -35,10 +35,6 @@ import { LayoutService } from '../layout.service.js';
   `,
   styles: [
     `
-      :root {
-        --bottom-nav-height: 56px;
-      }
-
       :host {
         display: block;
         height: 100%;

--- a/apps/web-client/src/app/layout/main-layout/main-layout.component.ts
+++ b/apps/web-client/src/app/layout/main-layout/main-layout.component.ts
@@ -1,7 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { HeaderComponent } from '../header/header.component.js';
 import { FooterComponent } from '../footer/footer.component.js';
+import { BottomNavComponent } from '../bottom-nav/bottom-nav.component.js';
+import { LayoutService } from '../layout.service.js';
 
 /**
  * MainLayoutComponent - Main application layout wrapper
@@ -10,25 +12,33 @@ import { FooterComponent } from '../footer/footer.component.js';
  * - Header with logo and theme toggle at the top
  * - Main content area with router-outlet
  * - Footer with copyright and GitHub link at the bottom
+ * - Bottom navigation bar on mobile (conditionally rendered)
  * - Flexbox layout with min-height: 100vh
  * - Content area grows to fill available space
  */
 @Component({
   selector: 'app-main-layout',
   standalone: true,
-  imports: [RouterOutlet, HeaderComponent, FooterComponent],
+  imports: [RouterOutlet, HeaderComponent, FooterComponent, BottomNavComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="main-layout">
       <app-header />
-      <main class="main-layout__content">
+      <main class="main-layout__content" [class.main-layout__content--mobile]="isMobile()">
         <router-outlet />
       </main>
+      @if (isMobile()) {
+        <app-bottom-nav />
+      }
       <app-footer />
     </div>
   `,
   styles: [
     `
+      :root {
+        --bottom-nav-height: 56px;
+      }
+
       :host {
         display: block;
         height: 100%;
@@ -49,7 +59,14 @@ import { FooterComponent } from '../footer/footer.component.js';
         transition: background-color var(--transition-normal);
         overflow: hidden;
       }
+
+      .main-layout__content--mobile {
+        padding-bottom: var(--bottom-nav-height);
+      }
     `,
   ],
 })
-export class MainLayoutComponent {}
+export class MainLayoutComponent {
+  private readonly layoutService = inject(LayoutService);
+  readonly isMobile = this.layoutService.isMobile;
+}

--- a/apps/web-client/src/styles.scss
+++ b/apps/web-client/src/styles.scss
@@ -71,6 +71,10 @@
   --scrollbar-track: transparent;
   --scrollbar-thumb: #345965;
   --scrollbar-thumb-hover: var(--primary);
+
+  // Layout
+  --bottom-nav-height: 56px;
+  --z-sticky: 50;
 }
 
 // =============================================================================

--- a/apps/web-client/src/styles/_variables.scss
+++ b/apps/web-client/src/styles/_variables.scss
@@ -84,6 +84,10 @@
   --z-modal: 500;
   --z-popover: 600;
   --z-tooltip: 700;
+
+  // Layout-specific z-index tokens
+  --z-bottom-nav: 40;
+  --bottom-nav-height: 56px;
 }
 
 // -----------------------------------------------------------------------------

--- a/docs/user_stories/40-hu-043-responsive-mobile-nav.md
+++ b/docs/user_stories/40-hu-043-responsive-mobile-nav.md
@@ -1,0 +1,144 @@
+# HU-043 — Navegación Responsive para Mobile y Tablet
+
+## Metadata
+
+| Campo         | Valor                                              |
+|---------------|----------------------------------------------------|
+| **ID**        | HU-043                                             |
+| **Épica**     | UI / Experiencia de usuario                        |
+| **Prioridad** | Alta                                               |
+| **Estado**    | Pendiente                                          |
+| **Rama**      | `feature/HU-043-responsive-mobile-nav`             |
+
+---
+
+## Historia de Usuario
+
+**Como** usuario de la biblioteca digital que accede desde un dispositivo móvil o tablet,
+**quiero** disponer de una barra de navegación inferior y una cabecera simplificada,
+**para** navegar cómodamente por la aplicación con una sola mano y aprovechar al máximo el espacio de pantalla disponible.
+
+---
+
+## Contexto y Motivación
+
+La aplicación funciona correctamente en desktop, pero en mobile y tablet el header horizontal no se adapta: los enlaces de navegación y el botón de autenticación quedan amontonados o desaparecen sin alternativa. El panel de filtros ya dispone de un drawer funcional en mobile (implementado en HU-042), por lo que esta historia se centra exclusivamente en la navegación global.
+
+El patrón elegido es **bottom navigation bar**: una barra fija en la parte inferior de la pantalla de 56px de alto, con iconos y etiquetas, que sustituye a los controles de navegación y autenticación del header en dispositivos móviles y tablets. Este patrón es el estándar nativo en aplicaciones móviles modernas (Material Design, iOS HIG) y maximiza la ergonomía con el pulgar.
+
+El breakpoint de mobile/tablet ya está definido en el proyecto mediante `BreakpointObserver` de Angular CDK (`Breakpoints.XSmall + Small`, equivalente a `max-width: 959px`) y se usa como señal reactiva `isMobile()` en `BookListPageComponent`. Esta lógica se elevará al `MainLayoutComponent` para compartirla con el header y el nuevo bottom nav.
+
+---
+
+## Criterios de Aceptación
+
+### CA-01 — Desktop sin cambios (ancho > 959px)
+- **Dado** que el usuario accede desde un dispositivo con ancho superior a 959px,
+- **cuando** carga cualquier página de la aplicación,
+- **entonces** el header muestra su contenido completo (marca, enlaces de navegación, botón de autenticación) y no aparece ninguna barra de navegación inferior.
+
+### CA-02 — Bottom nav visible en mobile/tablet (ancho <= 959px)
+- **Dado** que el usuario accede desde un dispositivo con ancho igual o inferior a 959px,
+- **cuando** carga cualquier página de la aplicación,
+- **entonces** aparece una barra de navegación fija en la parte inferior de la pantalla de 56px de alto.
+
+### CA-03 — Contenido del bottom nav cuando el usuario está autenticado
+- **Dado** que el usuario tiene sesión iniciada y está en mobile/tablet,
+- **cuando** observa la barra de navegación inferior,
+- **entonces** ve tres elementos:
+  - "Catálogo" con icono `menu_book` — navega a `/books`
+  - "Para ti" con icono `recommend` — navega a `/recommendations`
+  - Avatar/email con icono de logout — abre el dropdown de cierre de sesión
+
+### CA-04 — Contenido del bottom nav cuando el usuario no está autenticado
+- **Dado** que el usuario no tiene sesión iniciada y está en mobile/tablet,
+- **cuando** observa la barra de navegación inferior,
+- **entonces** ve únicamente el botón de "Iniciar sesión" con icono `account_circle`, que abre el modal de login existente.
+
+### CA-05 — Header simplificado en mobile/tablet
+- **Dado** que el usuario accede desde mobile/tablet,
+- **cuando** observa el header superior,
+- **entonces** solo ve la marca (logo + nombre "BiblioManager") y los enlaces de navegación y el botón de autenticación están ocultos (trasladados al bottom nav).
+
+### CA-06 — El contenido principal no queda tapado por el bottom nav
+- **Dado** que el bottom nav está visible (mobile/tablet),
+- **cuando** el usuario hace scroll hasta el final de cualquier página,
+- **entonces** el último elemento de contenido visible no queda oculto detrás de la barra inferior (el layout aplica un `padding-bottom` de 56px en mobile).
+
+### CA-07 — El drawer de filtros no queda tapado por el bottom nav
+- **Dado** que el usuario está en la página de catálogo en mobile,
+- **cuando** abre el drawer de filtros,
+- **entonces** el drawer se superpone correctamente sobre el bottom nav (z-index adecuado) y el backdrop cubre toda la pantalla incluyendo la zona del bottom nav.
+
+### CA-08 — El elemento activo del bottom nav está destacado visualmente
+- **Dado** que el usuario está en una página con entrada en el bottom nav,
+- **cuando** observa la barra inferior,
+- **entonces** el elemento correspondiente a la página actual aparece destacado visualmente (color accent `#17a1cf`), igual que el comportamiento de `routerLinkActive` en el header de desktop.
+
+---
+
+## Tareas Técnicas
+
+### T1 — Crear `BottomNavComponent`
+- Componente standalone en `src/app/layout/bottom-nav/`.
+- Recibe la señal `isMobile()` como `input()` o la consume desde un servicio compartido.
+- Renderiza los elementos de navegación con `routerLink` y `routerLinkActive`.
+- Gestiona el estado de autenticación (mismo patrón que el header: `AuthService.currentUser()`).
+- El botón de logout reutiliza la lógica existente del header.
+- El botón de login abre `LoginModalComponent` vía CDK Dialog (mismo patrón que el header).
+- `display: none` en desktop, `display: flex` en mobile (controlado por `@if (isMobile())`).
+- Tests unitarios: visibilidad según autenticación, active state, emit de acciones.
+
+### T2 — Elevar la señal `isMobile()` al `MainLayoutComponent`
+- Mover/duplicar el `BreakpointObserver` al `MainLayoutComponent` o crear un `LayoutService` inyectable que exponga `isMobile()` como signal.
+- `BookListPageComponent` pasa a consumirlo del servicio en lugar de instanciarlo localmente.
+- El `HeaderComponent` y el nuevo `BottomNavComponent` también lo consumen del mismo servicio.
+- Tests unitarios del servicio.
+
+### T3 — Actualizar `HeaderComponent`
+- Inyectar `LayoutService` (o la señal `isMobile()`).
+- Envolver los enlaces de navegación y el bloque de autenticación en `@if (!isMobile())`.
+- El bloque de la marca siempre es visible.
+- Actualizar tests existentes del header.
+
+### T4 — Actualizar `MainLayoutComponent`
+- Instanciar `BottomNavComponent` en el template.
+- Aplicar `padding-bottom: 56px` al contenedor `main-layout__content` condicionalmente cuando `isMobile()` es `true`.
+- Tests unitarios: verificar padding dinámico y presencia del bottom nav.
+
+### T5 — Ajuste de z-index y verificación visual
+- Revisar que el z-index del bottom nav (propuesta: `z-index: 40`) no interfiera con:
+  - El drawer de filtros de `BookListPageComponent` (actualmente `z-index: 50`)
+  - El backdrop del drawer (`z-index: 49` aproximado)
+  - El header sticky (`z-index: 100` aproximado)
+- Verificar en breakpoints: 320px, 480px, 768px, 959px, 1024px.
+- Ejecutar ESLint y corregir todos los warnings/errores.
+- Verificar que todos los tests pasan.
+
+---
+
+## Notas Técnicas
+
+- **No duplicar el BreakpointObserver**: la lógica de detección de mobile debe vivir en un único lugar (`LayoutService` o elevada al `MainLayoutComponent`). Actualmente vive en `BookListPageComponent`; se refactorizará en T2.
+- **Sin cambios en el panel de filtros**: el drawer ya funciona correctamente en mobile. Solo se ajusta el z-index si es necesario (T5).
+- **Bottom nav height**: 56px, estándar de Material Design. Esta constante debe ser definida como variable CSS (`--bottom-nav-height: 56px`) para que el padding del layout la consuma sin duplicar el valor.
+- **Reutilización de lógica de auth**: `BottomNavComponent` no reimplementa la lógica de login/logout — delega al mismo `AuthService` y al mismo `LoginModalComponent` que usa el header.
+- **Sin cambios en routing**: no se modifica ninguna ruta.
+
+---
+
+## Definición de Hecho (DoD)
+
+- [ ] `BottomNavComponent` implementado y con tests.
+- [ ] `LayoutService` (o señal elevada) implementado y consumido por header, bottom nav y book-list-page.
+- [ ] `HeaderComponent` oculta navegación y auth en mobile.
+- [ ] `MainLayoutComponent` renderiza el bottom nav y aplica padding dinámico.
+- [ ] El drawer de filtros no queda tapado ni interfiere con el bottom nav.
+- [ ] El elemento activo del bottom nav está visualmente destacado.
+- [ ] Verificación visual en 320px, 480px, 768px, 959px y 1024px.
+- [ ] Cobertura de tests: mínimo 80% en componentes y servicios nuevos.
+- [ ] ESLint: 0 errores, 0 warnings.
+- [ ] TypeCheck: sin errores de tipos.
+- [ ] Documentación en Notion actualizada:
+  - `Developer Documentation`: nuevo `BottomNavComponent`, `LayoutService`, cambios en `HeaderComponent` y `MainLayoutComponent`.
+  - `Product Overview`: HU-043 marcada como completada.


### PR DESCRIPTION
## Resumen

Implementa navegacion responsive para mobile y tablet (#471). En pantallas <= 959px la barra superior oculta los links de navegacion y el area de usuario, y aparece una bottom nav bar fija de 56px en la parte inferior.

## Cambios introducidos

### Nuevos componentes y servicios
- LayoutService: signal isMobile via BreakpointObserver (XSmall + Small)
- BottomNavComponent: barra fija inferior con navegacion auth-aware

### Componentes modificados
- HeaderComponent: oculta nav y actions en mobile con @if (!isMobile())
- MainLayoutComponent: integra bottom-nav y padding-bottom compensatorio
- BookListPageComponent: fuerza vista de cards en mobile

### Variables CSS globales
- --bottom-nav-height: 56px y --z-bottom-nav: 40 en _variables.scss
- z-index stack: bottom-nav=40 / drawer backdrop=49 / panel=50 / header=200

## Tests
- 66 tests en 5 archivos de layout -- todos verdes
- Cobertura: LayoutService, BottomNavComponent, HeaderComponent (mobile/desktop), MainLayoutComponent

## Issues
Closes #471